### PR TITLE
Fix issues #2-#5: profiles, migrations, bootstrap, core tasks

### DIFF
--- a/daemon/src/automation/scheduler.ts
+++ b/daemon/src/automation/scheduler.ts
@@ -9,6 +9,7 @@
 import { CronExpressionParser } from 'cron-parser';
 import { parseInterval, type TaskScheduleConfig } from '../core/config.js';
 import { runTask, type TaskResult } from './task-runner.js';
+import { registerCoreTasks } from './tasks/index.js';
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -43,6 +44,8 @@ export interface SchedulerOptions {
   getLastHumanActivity?: () => Date | null;
   /** Check if a named tmux session exists (for requiresSession tasks). */
   sessionExists?: () => boolean;
+  /** Auto-register built-in core task handlers (context-watchdog, todo-reminder, etc.). Defaults to true. */
+  autoRegisterCoreTasks?: boolean;
 }
 
 // ── Scheduler ────────────────────────────────────────────────
@@ -63,6 +66,11 @@ export class Scheduler {
     this._getLastHumanActivity = options.getLastHumanActivity;
     this._sessionExists = options.sessionExists;
     this._loadTasks(options.tasks);
+
+    // Auto-register built-in core task handlers unless explicitly disabled
+    if (options.autoRegisterCoreTasks !== false) {
+      registerCoreTasks(this);
+    }
   }
 
   // ── Public API ──────────────────────────────────────────

--- a/daemon/src/core/migrations/001-initial-schema.sql
+++ b/daemon/src/core/migrations/001-initial-schema.sql
@@ -1,7 +1,8 @@
 -- Kithkit v2 initial schema
+-- All tables use IF NOT EXISTS for idempotent re-runs (handles stale DB edge case).
 
 -- Agent registry (persistent agents + worker records)
-CREATE TABLE agents (
+CREATE TABLE IF NOT EXISTS agents (
   id TEXT PRIMARY KEY,
   type TEXT NOT NULL,
   profile TEXT,
@@ -16,7 +17,7 @@ CREATE TABLE agents (
 );
 
 -- Worker job tracking
-CREATE TABLE worker_jobs (
+CREATE TABLE IF NOT EXISTS worker_jobs (
   id TEXT PRIMARY KEY,
   agent_id TEXT REFERENCES agents(id),
   profile TEXT NOT NULL,
@@ -33,7 +34,7 @@ CREATE TABLE worker_jobs (
 );
 
 -- Memory entries with vector embeddings
-CREATE TABLE memories (
+CREATE TABLE IF NOT EXISTS memories (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   content TEXT NOT NULL,
   type TEXT DEFAULT 'fact',
@@ -46,7 +47,7 @@ CREATE TABLE memories (
 );
 
 -- Todos
-CREATE TABLE todos (
+CREATE TABLE IF NOT EXISTS todos (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   title TEXT NOT NULL,
   description TEXT,
@@ -59,7 +60,7 @@ CREATE TABLE todos (
 );
 
 -- Todo action history (audit trail)
-CREATE TABLE todo_actions (
+CREATE TABLE IF NOT EXISTS todo_actions (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   todo_id INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
   action TEXT NOT NULL,
@@ -70,7 +71,7 @@ CREATE TABLE todo_actions (
 );
 
 -- Calendar events
-CREATE TABLE calendar (
+CREATE TABLE IF NOT EXISTS calendar (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   title TEXT NOT NULL,
   description TEXT,
@@ -83,7 +84,7 @@ CREATE TABLE calendar (
 );
 
 -- Inter-agent messages (audit log + pull queue)
-CREATE TABLE messages (
+CREATE TABLE IF NOT EXISTS messages (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   from_agent TEXT NOT NULL,
   to_agent TEXT NOT NULL,
@@ -95,21 +96,21 @@ CREATE TABLE messages (
 );
 
 -- Runtime config overrides
-CREATE TABLE config (
+CREATE TABLE IF NOT EXISTS config (
   key TEXT PRIMARY KEY,
   value JSON NOT NULL,
   updated_at TEXT DEFAULT (datetime('now'))
 );
 
 -- Per-feature flexible state
-CREATE TABLE feature_state (
+CREATE TABLE IF NOT EXISTS feature_state (
   feature TEXT PRIMARY KEY,
   state JSON NOT NULL,
   updated_at TEXT DEFAULT (datetime('now'))
 );
 
 -- Scheduled task execution history
-CREATE TABLE task_results (
+CREATE TABLE IF NOT EXISTS task_results (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   task_name TEXT NOT NULL,
   status TEXT NOT NULL,

--- a/daemon/src/core/migrations/002-add-indexes.sql
+++ b/daemon/src/core/migrations/002-add-indexes.sql
@@ -3,31 +3,31 @@
 -- task_results, memories, todo_actions, and calendar.
 
 -- Messages: routed by to_agent, filtered by processed_at
-CREATE INDEX idx_messages_to_agent ON messages(to_agent);
-CREATE INDEX idx_messages_from_agent ON messages(from_agent);
-CREATE INDEX idx_messages_processed_at ON messages(processed_at);
+CREATE INDEX IF NOT EXISTS idx_messages_to_agent ON messages(to_agent);
+CREATE INDEX IF NOT EXISTS idx_messages_from_agent ON messages(from_agent);
+CREATE INDEX IF NOT EXISTS idx_messages_processed_at ON messages(processed_at);
 
 -- Worker jobs: looked up by agent_id and filtered by status
-CREATE INDEX idx_worker_jobs_agent_id ON worker_jobs(agent_id);
-CREATE INDEX idx_worker_jobs_status ON worker_jobs(status);
+CREATE INDEX IF NOT EXISTS idx_worker_jobs_agent_id ON worker_jobs(agent_id);
+CREATE INDEX IF NOT EXISTS idx_worker_jobs_status ON worker_jobs(status);
 
 -- Todos: filtered by status in context loader and API
-CREATE INDEX idx_todos_status ON todos(status);
+CREATE INDEX IF NOT EXISTS idx_todos_status ON todos(status);
 
 -- Agents: filtered by status and type in recovery and lifecycle
-CREATE INDEX idx_agents_status ON agents(status);
-CREATE INDEX idx_agents_type ON agents(type);
+CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
+CREATE INDEX IF NOT EXISTS idx_agents_type ON agents(type);
 
 -- Task results: looked up by task_name, ordered by created_at
-CREATE INDEX idx_task_results_task_name ON task_results(task_name);
-CREATE INDEX idx_task_results_started_at ON task_results(started_at);
+CREATE INDEX IF NOT EXISTS idx_task_results_task_name ON task_results(task_name);
+CREATE INDEX IF NOT EXISTS idx_task_results_started_at ON task_results(started_at);
 
 -- Memories: filtered by category and ordered by created_at
-CREATE INDEX idx_memories_category ON memories(category);
-CREATE INDEX idx_memories_created_at ON memories(created_at);
+CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
+CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at);
 
 -- Todo actions: looked up by todo_id for audit trail
-CREATE INDEX idx_todo_actions_todo_id ON todo_actions(todo_id);
+CREATE INDEX IF NOT EXISTS idx_todo_actions_todo_id ON todo_actions(todo_id);
 
 -- Calendar: filtered and ordered by start_time
-CREATE INDEX idx_calendar_start_time ON calendar(start_time);
+CREATE INDEX IF NOT EXISTS idx_calendar_start_time ON calendar(start_time);

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -12,7 +12,7 @@ import { initLogger, createLogger } from './core/logger.js';
 import { getHealth } from './core/health.js';
 import { handleStateRoute } from './api/state.js';
 import { handleMemoryRoute } from './api/memory.js';
-import { handleAgentsRoute } from './api/agents.js';
+import { handleAgentsRoute, setProfilesDir } from './api/agents.js';
 import { handleMessagesRoute } from './api/messages.js';
 import { handleSendRoute } from './api/send.js';
 import { handleTasksRoute } from './api/tasks.js';
@@ -90,6 +90,7 @@ const log = createLogger('main');
 // ── Database ─────────────────────────────────────────────────
 
 openDatabase(projectDir);
+setProfilesDir(path.resolve(projectDir, '.claude', 'agents'));
 
 log.info('Kithkit daemon starting', {
   agent: config.agent.name,
@@ -218,6 +219,11 @@ function tryListen(): void {
 
     // Extension init hook — runs after server is listening
     const ext = getExtension();
+    if (!ext) {
+      log.warn('No extension registered — daemon is running without an agent extension. ' +
+        'If you expected an extension, make sure your entry point calls registerExtension() ' +
+        'before importing main.ts (e.g., use bootstrap.ts as the entry point).');
+    }
     if (ext?.onInit) {
       const initStart = Date.now();
       try {
@@ -288,11 +294,23 @@ process.on('unhandledRejection', (reason) => {
 });
 
 process.on('uncaughtException', (err) => {
-  log.error('Uncaught exception — shutting down', {
-    error: err.message,
-    stack: err.stack,
-  });
-  shutdown('uncaughtException').catch(() => process.exit(1));
+  const ext = getExtension();
+  if (ext && !isDegraded()) {
+    // When an extension is loaded, try degraded mode instead of shutting down.
+    // This handles async errors from extension child processes, timers, etc.
+    log.error('Uncaught exception — entering degraded mode (extension disabled)', {
+      error: err.message,
+      stack: err.stack,
+    });
+    setDegraded(true);
+  } else {
+    // No extension or already degraded — fatal, shut down
+    log.error('Uncaught exception — shutting down', {
+      error: err.message,
+      stack: err.stack,
+    });
+    shutdown('uncaughtException').catch(() => process.exit(1));
+  }
 });
 
 log.info('Daemon initialized');

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,9 +67,11 @@ cli/
 
 The daemon is a persistent Node.js HTTP server (`127.0.0.1:<port>`, default 3847) that manages all agent state and background services. It starts via `scripts/start-tmux.sh` (which launches both the daemon and a Claude Code session in tmux).
 
+**Entry point**: Agent repos should use a `bootstrap.ts` file as the daemon entry point (not `main.ts` directly). `bootstrap.ts` calls `registerExtension()` before importing `main.ts`. Running `main.ts` directly starts a bare daemon with no extension — no scheduler tasks, no communication channels, no personality. The daemon logs a warning at startup when no extension is registered.
+
 ```
 daemon/src/
-├── main.ts              # Entry point — bootstrap, server, route dispatch
+├── main.ts              # Core daemon — server, route dispatch (bare without extension)
 ├── core/                # Foundation services
 ├── api/                 # HTTP route handlers
 ├── agents/              # Worker lifecycle

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,7 +138,7 @@ Human ←→ Comms Agent ←→ Daemon ←→ Workers
 
 **Comms agent** — the Claude Code session with your agent's personality. Handles conversations directly and delegates complex tasks to workers.
 
-**Daemon** — a background HTTP server on localhost. Manages state (todos, calendar, memories), agent lifecycle, scheduling, and channel routing. Everything goes through its API.
+**Daemon** — a background HTTP server on localhost. Manages state (todos, calendar, memories), agent lifecycle, scheduling, and channel routing. Everything goes through its API. Agent repos use a `bootstrap.ts` entry point that registers the extension before starting the daemon — running `main.ts` directly starts a bare daemon with no extension loaded.
 
 **Workers** — ephemeral Claude Code agents scoped by profiles (research, coding, testing, etc.). Each profile defines allowed tools, model, and turn limits. The comms agent spawns workers on demand.
 


### PR DESCRIPTION
## Summary

Addresses 4 open issues with framework-level fixes, plus a partial fix for #1:

- **#5** (profiles dir): Call `setProfilesDir()` in `main.ts` so `POST /api/agents/spawn` can find agent profiles in `.claude/agents/`
- **#3** (idempotent migrations): Add `IF NOT EXISTS` to all `CREATE TABLE` and `CREATE INDEX` statements in migration SQL — handles the stale DB edge case without special logic
- **#2** (bootstrap.js docs): Log a warning at startup when no extension is registered (bare daemon). Updated architecture and getting-started docs to explain the `bootstrap.ts` entry point pattern
- **#4** (core scheduler tasks): Scheduler constructor now auto-registers core task handlers (context-watchdog, todo-reminder, approval-audit, backup) by default. Extensions can opt out with `autoRegisterCoreTasks: false`
- **#1** (partial — framework layer only): `uncaughtException` handler now enters degraded mode instead of crashing when an extension is loaded. Core API endpoints remain available. Extension-level voice fix (pre-spawn validation) is separate work

## Test plan

- [x] `npm run build` passes with no new errors
- [x] `npm test` — same 7 pre-existing failures (task-runner shell security), zero new failures
- [ ] Verify `POST /api/agents/spawn` finds profiles after daemon start
- [ ] Verify stale DB (empty migrations table + existing tables) no longer crashes
- [ ] Verify bare daemon logs warning about missing extension

Closes #2, closes #3, closes #4, closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)