### PR TITLE
Add task queue, activity log, and direct channel (Orchestrator v2 Phase 3)

### DIFF
--- a/daemon/src/__tests__/message-router.test.ts
+++ b/daemon/src/__tests__/message-router.test.ts
@@ -461,3 +461,113 @@ describe('Messages API validation', () => {
     assert.ok(JSON.parse(res.body).error.includes('agent'));
   });
 });
+
+describe('Direct channel — immediate delivery for persistent agents', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('direct=true injects immediately and sets processed_at', () => {
+    const injected: { session: string; text: string }[] = [];
+    _setTmuxInjectorForTesting((session, text) => {
+      injected.push({ session, text });
+      return true;
+    });
+
+    const result = sendMessage({
+      from: 'orchestrator',
+      to: 'comms',
+      type: 'text',
+      body: 'Quick question about the spec',
+      direct: true,
+    });
+
+    assert.equal(result.delivered, true);
+    assert.equal(injected.length, 1);
+    assert.ok(injected[0].text.includes('Quick question about the spec'));
+
+    // Message should be marked as processed
+    const messages = query<Message>('SELECT * FROM messages WHERE id = ?', result.messageId);
+    assert.equal(messages.length, 1);
+    assert.ok(messages[0].processed_at, 'processed_at should be set for direct delivery');
+  });
+
+  it('direct=true falls back to queued delivery if injection fails', () => {
+    _setTmuxInjectorForTesting(() => false);
+
+    const result = sendMessage({
+      from: 'orchestrator',
+      to: 'comms',
+      type: 'text',
+      body: 'Session is down',
+      direct: true,
+    });
+
+    // Falls back to queued delivery
+    assert.equal(result.delivered, false);
+
+    // processed_at should NOT be set (needs to be delivered by scheduler)
+    const messages = query<Message>('SELECT * FROM messages WHERE id = ?', result.messageId);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].processed_at, null);
+  });
+
+  it('direct=false (default) queues for scheduler delivery', () => {
+    const injected: { session: string; text: string }[] = [];
+    _setTmuxInjectorForTesting((session, text) => {
+      injected.push({ session, text });
+      return true;
+    });
+
+    const result = sendMessage({
+      from: 'orchestrator',
+      to: 'comms',
+      type: 'result',
+      body: 'Research complete',
+    });
+
+    // No immediate injection
+    assert.equal(injected.length, 0);
+    assert.equal(result.delivered, false);
+  });
+
+  it('direct=true has no effect for worker targets', () => {
+    const injected: { session: string; text: string }[] = [];
+    _setTmuxInjectorForTesting((session, text) => {
+      injected.push({ session, text });
+      return true;
+    });
+
+    const result = sendMessage({
+      from: 'orchestrator',
+      to: 'worker-abc',
+      type: 'task',
+      body: 'Do work',
+      direct: true,
+    });
+
+    // Workers pull their own messages — no injection
+    assert.equal(injected.length, 0);
+    assert.equal(result.delivered, true);
+  });
+
+  it('POST /api/messages with direct=true passes through to sendMessage', async () => {
+    const injected: { session: string; text: string }[] = [];
+    _setTmuxInjectorForTesting((session, text) => {
+      injected.push({ session, text });
+      return true;
+    });
+
+    const res = await request('POST', '/api/messages', {
+      from: 'orchestrator',
+      to: 'comms',
+      type: 'text',
+      body: 'Direct via API',
+      direct: true,
+    });
+
+    assert.equal(res.status, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.delivered, true);
+    assert.equal(injected.length, 1);
+  });
+});

--- a/daemon/src/__tests__/task-queue.test.ts
+++ b/daemon/src/__tests__/task-queue.test.ts
@@ -1,0 +1,537 @@
+/**
+ * Task Queue API tests — orchestrator task management.
+ *
+ * Tests task CRUD, state machine transitions, activity log,
+ * worker assignment, and status/assignee validation.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { openDatabase, _resetDbForTesting } from '../core/db.js';
+import { handleTaskQueueRoute } from '../api/task-queue.js';
+
+const TEST_PORT = 19870;
+
+function request(
+  method: string,
+  urlPath: string,
+  body?: unknown,
+): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const opts: http.RequestOptions = {
+      host: '127.0.0.1',
+      port: TEST_PORT,
+      path: urlPath,
+      method,
+      timeout: 5000,
+      headers: {
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+        'Connection': 'close',
+      },
+    };
+    const r = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data, headers: res.headers }));
+    });
+    r.on('error', reject);
+    r.on('timeout', () => { r.destroy(); reject(new Error('timeout')); });
+    if (body !== undefined) r.write(JSON.stringify(body));
+    r.end();
+  });
+}
+
+let server: http.Server;
+let tmpDir: string;
+
+function setup(): Promise<void> {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kithkit-taskq-'));
+  _resetDbForTesting();
+  openDatabase(tmpDir, path.join(tmpDir, 'test.db'));
+
+  server = http.createServer((inReq, res) => {
+    const url = new URL(inReq.url ?? '/', `http://localhost:${TEST_PORT}`);
+    res.setHeader('X-Timestamp', new Date().toISOString());
+    handleTaskQueueRoute(inReq, res, url.pathname, url.searchParams)
+      .then((handled) => {
+        if (!handled) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Not found', timestamp: new Date().toISOString() }));
+        }
+      })
+      .catch((err) => {
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: String(err), timestamp: new Date().toISOString() }));
+        }
+      });
+  });
+
+  return new Promise<void>((resolve) => {
+    server.listen(TEST_PORT, '127.0.0.1', resolve);
+  });
+}
+
+function teardown(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    _resetDbForTesting();
+    if (server?.listening) {
+      server.close(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        resolve();
+      });
+    } else {
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+      resolve();
+    }
+  });
+}
+
+/** Helper: create a task and return the parsed body. */
+async function createTask(overrides: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+  const res = await request('POST', '/api/orchestrator/tasks', {
+    title: 'Test task',
+    description: 'Do the thing',
+    ...overrides,
+  });
+  assert.equal(res.status, 201);
+  return JSON.parse(res.body);
+}
+
+describe('Task Queue API', { concurrency: 1 }, () => {
+
+  // ── Task CRUD ──────────────────────────────────────────────
+
+  describe('Task CRUD', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('creates a task with defaults', async () => {
+      const task = await createTask();
+      assert.ok(task.id, 'Should have a UUID id');
+      assert.equal(task.title, 'Test task');
+      assert.equal(task.description, 'Do the thing');
+      assert.equal(task.status, 'pending');
+      assert.equal(task.assignee, null);
+      assert.equal(task.priority, 0);
+      assert.ok(task.created_at);
+      assert.ok(task.updated_at);
+      assert.ok(task.timestamp, 'Response should include timestamp');
+    });
+
+    it('creates a task with priority', async () => {
+      const task = await createTask({ priority: 2 });
+      assert.equal(task.priority, 2);
+    });
+
+    it('rejects invalid priority', async () => {
+      const res = await request('POST', '/api/orchestrator/tasks', { title: 'Bad', priority: 5 });
+      assert.equal(res.status, 400);
+      assert.ok(JSON.parse(res.body).error.includes('priority'));
+    });
+
+    it('rejects missing title', async () => {
+      const res = await request('POST', '/api/orchestrator/tasks', { description: 'no title' });
+      assert.equal(res.status, 400);
+    });
+
+    it('lists tasks ordered by priority DESC, created_at ASC', async () => {
+      await createTask({ title: 'Low', priority: 0 });
+      await createTask({ title: 'Urgent', priority: 2 });
+      await createTask({ title: 'High', priority: 1 });
+
+      const res = await request('GET', '/api/orchestrator/tasks');
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.data.length, 3);
+      assert.equal(body.data[0].title, 'Urgent');
+      assert.equal(body.data[1].title, 'High');
+      assert.equal(body.data[2].title, 'Low');
+    });
+
+    it('filters tasks by status', async () => {
+      const t1 = await createTask({ title: 'Pending' });
+      await createTask({ title: 'Also pending' });
+
+      // Move t1 to assigned
+      await request('PUT', `/api/orchestrator/tasks/${t1.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+
+      const res = await request('GET', '/api/orchestrator/tasks?status=pending');
+      const body = JSON.parse(res.body);
+      assert.equal(body.data.length, 1);
+      assert.equal(body.data[0].title, 'Also pending');
+    });
+
+    it('filters tasks by multiple statuses', async () => {
+      const t1 = await createTask({ title: 'Pending' });
+      await request('PUT', `/api/orchestrator/tasks/${t1.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await createTask({ title: 'Also pending' });
+
+      const res = await request('GET', '/api/orchestrator/tasks?status=pending,assigned');
+      const body = JSON.parse(res.body);
+      assert.equal(body.data.length, 2);
+    });
+
+    it('gets task detail with workers and activity', async () => {
+      const task = await createTask();
+
+      const res = await request('GET', `/api/orchestrator/tasks/${task.id}`);
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.id, task.id);
+      assert.ok(Array.isArray(body.workers));
+      assert.ok(Array.isArray(body.activity));
+    });
+
+    it('returns 404 for nonexistent task', async () => {
+      const res = await request('GET', '/api/orchestrator/tasks/nonexistent-uuid');
+      assert.equal(res.status, 404);
+    });
+  });
+
+  // ── State Machine ──────────────────────────────────────────
+
+  describe('State Machine', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('transitions pending → assigned', async () => {
+      const task = await createTask();
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'assigned');
+      assert.equal(body.assignee, 'orchestrator');
+      assert.ok(body.assigned_at);
+    });
+
+    it('transitions assigned → in_progress', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'in_progress');
+      assert.ok(body.started_at);
+    });
+
+    it('transitions in_progress → completed', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'completed', result: 'All done',
+      });
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'completed');
+      assert.equal(body.result, 'All done');
+      assert.ok(body.completed_at);
+    });
+
+    it('transitions in_progress → failed', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'failed', error: 'Something went wrong',
+      });
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'failed');
+      assert.equal(body.error, 'Something went wrong');
+    });
+
+    it('rejects invalid transition pending → completed', async () => {
+      const task = await createTask();
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'completed',
+      });
+      assert.equal(res.status, 409);
+      const body = JSON.parse(res.body);
+      assert.ok(body.error.includes('cannot transition'));
+    });
+
+    it('rejects invalid transition pending → in_progress', async () => {
+      const task = await createTask();
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      assert.equal(res.status, 409);
+    });
+
+    it('rejects updates to completed tasks', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'completed', result: 'Done',
+      });
+
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'pending',
+      });
+      assert.equal(res.status, 409);
+      assert.ok(JSON.parse(res.body).error.includes('Cannot update completed'));
+    });
+
+    it('allows assigned → pending (return to queue)', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'pending',
+      });
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'pending');
+      assert.equal(body.assignee, null, 'Assignee should be cleared on return to pending');
+    });
+  });
+
+  // ── Assignee/Status Validation ─────────────────────────────
+
+  describe('Assignee/Status Validation', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('rejects assigned status without assignee', async () => {
+      const task = await createTask();
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned',
+      });
+      assert.equal(res.status, 400);
+      assert.ok(JSON.parse(res.body).error.includes('assignee'));
+    });
+
+    it('allows setting assignee without changing status', async () => {
+      const task = await createTask();
+      // This should fail because pending + assignee is invalid
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        assignee: 'orchestrator',
+      });
+      assert.equal(res.status, 400);
+      assert.ok(JSON.parse(res.body).error.includes('pending'));
+    });
+
+    it('allows setting both status and assignee in one request', async () => {
+      const task = await createTask();
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned',
+        assignee: 'worker-abc-123',
+      });
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'assigned');
+      assert.equal(body.assignee, 'worker-abc-123');
+    });
+  });
+
+  // ── Activity Log ───────────────────────────────────────────
+
+  describe('Activity Log', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('posts a progress activity entry', async () => {
+      const task = await createTask();
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/activity`, {
+        type: 'progress',
+        stage: 'spawning_workers',
+        message: 'Spawned 2 research workers',
+        agent: 'orchestrator',
+      });
+      assert.equal(res.status, 201);
+      const body = JSON.parse(res.body);
+      assert.equal(body.type, 'progress');
+      assert.equal(body.stage, 'spawning_workers');
+      assert.equal(body.agent, 'orchestrator');
+    });
+
+    it('posts a note activity entry', async () => {
+      const task = await createTask();
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/activity`, {
+        type: 'note',
+        message: 'This depends on the API reference',
+        agent: 'orchestrator',
+      });
+      assert.equal(res.status, 201);
+      const body = JSON.parse(res.body);
+      assert.equal(body.type, 'note');
+      assert.equal(body.stage, null);
+    });
+
+    it('rejects activity with missing message', async () => {
+      const task = await createTask();
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/activity`, {
+        type: 'progress',
+        agent: 'orchestrator',
+      });
+      assert.equal(res.status, 400);
+    });
+
+    it('rejects activity with invalid type', async () => {
+      const task = await createTask();
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/activity`, {
+        type: 'invalid',
+        message: 'Test',
+        agent: 'orchestrator',
+      });
+      assert.equal(res.status, 400);
+    });
+
+    it('gets activity log with pagination', async () => {
+      const task = await createTask();
+
+      // Post 5 activity entries
+      for (let i = 0; i < 5; i++) {
+        await request('POST', `/api/orchestrator/tasks/${task.id}/activity`, {
+          type: 'note',
+          message: `Entry ${i}`,
+          agent: 'orchestrator',
+        });
+      }
+
+      // Get with limit
+      const res = await request('GET', `/api/orchestrator/tasks/${task.id}/activity?limit=2&offset=0`);
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.data.length, 2);
+      assert.equal(body.total, 5);
+      assert.equal(body.data[0].message, 'Entry 0');
+
+      // Get with offset
+      const res2 = await request('GET', `/api/orchestrator/tasks/${task.id}/activity?limit=2&offset=2`);
+      const body2 = JSON.parse(res2.body);
+      assert.equal(body2.data.length, 2);
+      assert.equal(body2.data[0].message, 'Entry 2');
+    });
+
+    it('returns 404 for activity on nonexistent task', async () => {
+      const res = await request('GET', '/api/orchestrator/tasks/bad-id/activity');
+      assert.equal(res.status, 404);
+    });
+  });
+
+  // ── Worker Assignment ──────────────────────────────────────
+
+  describe('Worker Assignment', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('assigns a worker to a task', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/workers`, {
+        worker_id: 'worker-abc-123',
+        role: 'research',
+      });
+      assert.equal(res.status, 201);
+      const body = JSON.parse(res.body);
+      assert.equal(body.worker_id, 'worker-abc-123');
+      assert.equal(body.role, 'research');
+    });
+
+    it('rejects duplicate worker assignment', async () => {
+      const task = await createTask();
+      await request('POST', `/api/orchestrator/tasks/${task.id}/workers`, {
+        worker_id: 'worker-abc-123',
+      });
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/workers`, {
+        worker_id: 'worker-abc-123',
+      });
+      assert.equal(res.status, 409);
+    });
+
+    it('rejects worker assignment to completed task', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'completed', result: 'Done',
+      });
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/workers`, {
+        worker_id: 'worker-abc-123',
+      });
+      assert.equal(res.status, 409);
+    });
+
+    it('shows workers in task detail', async () => {
+      const task = await createTask();
+      await request('POST', `/api/orchestrator/tasks/${task.id}/workers`, {
+        worker_id: 'worker-1',
+        role: 'research',
+      });
+      await request('POST', `/api/orchestrator/tasks/${task.id}/workers`, {
+        worker_id: 'worker-2',
+        role: 'coding',
+      });
+
+      const res = await request('GET', `/api/orchestrator/tasks/${task.id}`);
+      const body = JSON.parse(res.body);
+      assert.equal(body.workers.length, 2);
+      assert.equal(body.workers[0].role, 'research');
+      assert.equal(body.workers[1].role, 'coding');
+    });
+  });
+
+  // ── Rapid-fire Escalation (Success Criterion 1) ────────────
+
+  describe('Rapid-fire task creation', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('queues 5 tasks in rapid succession without loss', async () => {
+      const results = await Promise.all([
+        createTask({ title: 'Task 1' }),
+        createTask({ title: 'Task 2' }),
+        createTask({ title: 'Task 3' }),
+        createTask({ title: 'Task 4' }),
+        createTask({ title: 'Task 5' }),
+      ]);
+
+      assert.equal(results.length, 5);
+      const ids = new Set(results.map(r => r.id));
+      assert.equal(ids.size, 5, 'All tasks should have unique IDs');
+
+      const listRes = await request('GET', '/api/orchestrator/tasks?status=pending');
+      const body = JSON.parse(listRes.body);
+      assert.equal(body.data.length, 5);
+    });
+  });
+});

--- a/daemon/src/agents/message-router.ts
+++ b/daemon/src/agents/message-router.ts
@@ -34,6 +34,7 @@ export interface SendMessageRequest {
   type: MessageType;
   body: string;
   metadata?: Record<string, unknown>;
+  direct?: boolean;
 }
 
 const VALID_MESSAGE_TYPES: MessageType[] = ['text', 'task', 'result', 'error', 'status'];
@@ -108,6 +109,21 @@ export function sendMessage(req: SendMessageRequest): { messageId: number; deliv
 
   // Route to target
   if (isPersistentAgent(req.to)) {
+    // Direct channel: bypass scheduler and inject immediately
+    if (req.direct) {
+      const formatted = formatForTmux(req);
+      const injected = tmuxInjector(req.to, formatted);
+      if (injected) {
+        // Mark as processed — deliver-once, no re-notification
+        exec(
+          'UPDATE messages SET processed_at = ? WHERE id = ?',
+          new Date().toISOString(), message.id,
+        );
+        return { messageId: message.id, delivered: true };
+      }
+      // Injection failed (session not alive) — fall through to normal delivery
+    }
+
     // Queue for delivery — the message-delivery scheduler task handles tmux injection.
     // Trigger the task immediately so delivery doesn't wait for the next interval tick.
     notifyNewMessage();

--- a/daemon/src/api/messages.ts
+++ b/daemon/src/api/messages.ts
@@ -70,6 +70,7 @@ export async function handleMessagesRoute(
           type: (body.type as MessageType) ?? 'text',
           body: body.body as string,
           metadata: typeof body.metadata === 'object' ? body.metadata as Record<string, unknown> : undefined,
+          direct: body.direct === true,
         });
 
         json(res, 200, withTimestamp({

--- a/daemon/src/api/task-queue.ts
+++ b/daemon/src/api/task-queue.ts
@@ -1,0 +1,468 @@
+/**
+ * Task Queue API — structured task management for orchestrator work.
+ *
+ * State machine: pending → assigned → in_progress → completed/failed
+ *
+ * Routes:
+ *   POST   /api/orchestrator/tasks              — Create a task
+ *   GET    /api/orchestrator/tasks              — List tasks (filterable by status)
+ *   GET    /api/orchestrator/tasks/:id          — Get task detail (+ workers + activity)
+ *   PUT    /api/orchestrator/tasks/:id          — Update task (status, assignee, result)
+ *   POST   /api/orchestrator/tasks/:id/activity — Post activity entry
+ *   GET    /api/orchestrator/tasks/:id/activity — Get activity log (paginated)
+ *   POST   /api/orchestrator/tasks/:id/workers  — Assign worker to task
+ */
+
+import type http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { json, withTimestamp, parseBody } from './helpers.js';
+import { query, exec, get } from '../core/db.js';
+import { injectMessage } from '../agents/tmux.js';
+import { createLogger } from '../core/logger.js';
+
+const log = createLogger('task-queue');
+
+// ── Types ────────────────────────────────────────────────────
+
+type TaskStatus = 'pending' | 'assigned' | 'in_progress' | 'completed' | 'failed';
+type ActivityType = 'progress' | 'note';
+
+interface OrchestratorTask {
+  id: string;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  assignee: string | null;
+  priority: number;
+  result: string | null;
+  error: string | null;
+  timeout_seconds: number | null;
+  created_at: string;
+  assigned_at: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  updated_at: string;
+}
+
+interface TaskWorker {
+  task_id: string;
+  worker_id: string;
+  role: string | null;
+  assigned_at: string;
+}
+
+interface TaskActivity {
+  id: number;
+  task_id: string;
+  agent: string;
+  type: ActivityType;
+  stage: string | null;
+  message: string;
+  created_at: string;
+}
+
+// ── Constants ────────────────────────────────────────────────
+
+const VALID_STATUSES: readonly TaskStatus[] = ['pending', 'assigned', 'in_progress', 'completed', 'failed'];
+const TERMINAL_STATUSES: readonly TaskStatus[] = ['completed', 'failed'];
+const VALID_ACTIVITY_TYPES: readonly ActivityType[] = ['progress', 'note'];
+
+/**
+ * Valid status transitions. Key = current status, value = allowed next statuses.
+ */
+const VALID_TRANSITIONS: Record<TaskStatus, readonly TaskStatus[]> = {
+  pending: ['assigned', 'failed'],
+  assigned: ['in_progress', 'failed', 'pending'],
+  in_progress: ['completed', 'failed'],
+  completed: [],
+  failed: [],
+};
+
+// ── Validation ───────────────────────────────────────────────
+
+/**
+ * Validate status + assignee combination per spec drift rules.
+ * Returns error string or null if valid.
+ */
+function validateStatusAssignee(status: TaskStatus, assignee: string | null): string | null {
+  if (status === 'pending' && assignee !== null) {
+    return 'pending tasks must have null assignee';
+  }
+  if (status === 'assigned' && !assignee) {
+    return 'assigned tasks require a non-null assignee';
+  }
+  return null;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function extractTaskId(pathname: string): string | null {
+  const match = pathname.match(/^\/api\/orchestrator\/tasks\/([^/]+)/);
+  return match ? match[1]! : null;
+}
+
+function getTask(id: string): OrchestratorTask | undefined {
+  return get<OrchestratorTask>('orchestrator_tasks', id);
+}
+
+function getTaskWorkers(taskId: string): TaskWorker[] {
+  return query<TaskWorker>(
+    'SELECT * FROM orchestrator_task_workers WHERE task_id = ? ORDER BY assigned_at ASC',
+    taskId,
+  );
+}
+
+function getTaskActivity(taskId: string, limit = 50, offset = 0): { data: TaskActivity[]; total: number } {
+  const safeLimit = Math.min(Math.max(1, limit), 200);
+  const safeOffset = Math.max(0, offset);
+
+  const countRow = query<{ count: number }>(
+    'SELECT COUNT(*) as count FROM orchestrator_task_activity WHERE task_id = ?',
+    taskId,
+  );
+  const total = countRow[0]?.count ?? 0;
+
+  const data = query<TaskActivity>(
+    'SELECT * FROM orchestrator_task_activity WHERE task_id = ? ORDER BY created_at ASC LIMIT ? OFFSET ?',
+    taskId, safeLimit, safeOffset,
+  );
+
+  return { data, total };
+}
+
+// ── Route handler ────────────────────────────────────────────
+
+export async function handleTaskQueueRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  pathname: string,
+  searchParams: URLSearchParams,
+): Promise<boolean> {
+  const method = req.method ?? 'GET';
+
+  // Only handle /api/orchestrator/tasks* routes
+  if (!pathname.startsWith('/api/orchestrator/tasks')) return false;
+
+  try {
+    // POST /api/orchestrator/tasks — create a task
+    if (pathname === '/api/orchestrator/tasks' && method === 'POST') {
+      const body = await parseBody(req);
+
+      if (!body.title || typeof body.title !== 'string') {
+        json(res, 400, withTimestamp({ error: 'title is required' }));
+        return true;
+      }
+
+      const priority = typeof body.priority === 'number' ? body.priority : 0;
+      if (priority < 0 || priority > 2) {
+        json(res, 400, withTimestamp({ error: 'priority must be 0 (normal), 1 (high), or 2 (urgent)' }));
+        return true;
+      }
+
+      const id = randomUUID();
+      const ts = now();
+
+      exec(
+        `INSERT INTO orchestrator_tasks (id, title, description, status, priority, timeout_seconds, created_at, updated_at)
+         VALUES (?, ?, ?, 'pending', ?, ?, ?, ?)`,
+        id,
+        body.title,
+        typeof body.description === 'string' ? body.description : null,
+        priority,
+        typeof body.timeout_seconds === 'number' ? body.timeout_seconds : null,
+        ts,
+        ts,
+      );
+
+      const task = getTask(id)!;
+      log.info('Task created', { id, title: task.title, priority });
+      json(res, 201, withTimestamp(task));
+      return true;
+    }
+
+    // GET /api/orchestrator/tasks — list tasks
+    if (pathname === '/api/orchestrator/tasks' && method === 'GET') {
+      const statusFilter = searchParams.get('status');
+      let tasks: OrchestratorTask[];
+
+      if (statusFilter) {
+        const statuses = statusFilter.split(',').map(s => s.trim());
+        const invalid = statuses.filter(s => !VALID_STATUSES.includes(s as TaskStatus));
+        if (invalid.length > 0) {
+          json(res, 400, withTimestamp({ error: `invalid status filter: ${invalid.join(', ')}` }));
+          return true;
+        }
+        const placeholders = statuses.map(() => '?').join(',');
+        tasks = query<OrchestratorTask>(
+          `SELECT * FROM orchestrator_tasks WHERE status IN (${placeholders}) ORDER BY priority DESC, created_at ASC`,
+          ...statuses,
+        );
+      } else {
+        tasks = query<OrchestratorTask>(
+          'SELECT * FROM orchestrator_tasks ORDER BY priority DESC, created_at ASC',
+        );
+      }
+
+      // Attach latest activity and worker count to each task
+      const enriched = tasks.map(task => {
+        const workers = getTaskWorkers(task.id);
+        const latestActivity = query<TaskActivity>(
+          'SELECT * FROM orchestrator_task_activity WHERE task_id = ? ORDER BY created_at DESC LIMIT 1',
+          task.id,
+        );
+        return {
+          ...task,
+          worker_count: workers.length,
+          latest_activity: latestActivity[0] ?? null,
+        };
+      });
+
+      json(res, 200, withTimestamp({ data: enriched }));
+      return true;
+    }
+
+    // Routes with task ID
+    const taskId = extractTaskId(pathname);
+    if (!taskId) return false;
+
+    // Check for sub-routes: /activity, /workers
+    const subpath = pathname.slice(`/api/orchestrator/tasks/${taskId}`.length);
+
+    // GET /api/orchestrator/tasks/:id/activity — get activity log
+    if (subpath === '/activity' && method === 'GET') {
+      const task = getTask(taskId);
+      if (!task) {
+        json(res, 404, withTimestamp({ error: 'Task not found' }));
+        return true;
+      }
+
+      const limit = parseInt(searchParams.get('limit') ?? '50', 10);
+      const offset = parseInt(searchParams.get('offset') ?? '0', 10);
+      const result = getTaskActivity(taskId, isNaN(limit) ? 50 : limit, isNaN(offset) ? 0 : offset);
+
+      json(res, 200, withTimestamp({ data: result.data, total: result.total }));
+      return true;
+    }
+
+    // POST /api/orchestrator/tasks/:id/activity — post activity entry
+    if (subpath === '/activity' && method === 'POST') {
+      const task = getTask(taskId);
+      if (!task) {
+        json(res, 404, withTimestamp({ error: 'Task not found' }));
+        return true;
+      }
+
+      const body = await parseBody(req);
+
+      if (!body.message || typeof body.message !== 'string') {
+        json(res, 400, withTimestamp({ error: 'message is required' }));
+        return true;
+      }
+
+      const type = (typeof body.type === 'string' ? body.type : 'note') as ActivityType;
+      if (!VALID_ACTIVITY_TYPES.includes(type)) {
+        json(res, 400, withTimestamp({ error: `type must be one of: ${VALID_ACTIVITY_TYPES.join(', ')}` }));
+        return true;
+      }
+
+      const agent = typeof body.agent === 'string' ? body.agent : 'unknown';
+      const stage = typeof body.stage === 'string' ? body.stage : null;
+      const ts = now();
+
+      exec(
+        `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        taskId, agent, type, stage, body.message, ts,
+      );
+
+      // For progress updates, forward to comms session immediately
+      if (type === 'progress') {
+        const prefix = stage ? `${stage}: ` : '';
+        injectMessage('comms', `[task ${task.title}] ${prefix}${body.message}`);
+      }
+
+      const entry = query<TaskActivity>(
+        'SELECT * FROM orchestrator_task_activity WHERE task_id = ? ORDER BY id DESC LIMIT 1',
+        taskId,
+      );
+
+      log.info('Activity posted', { taskId, type, agent });
+      json(res, 201, withTimestamp(entry[0]!));
+      return true;
+    }
+
+    // POST /api/orchestrator/tasks/:id/workers — assign worker to task
+    if (subpath === '/workers' && method === 'POST') {
+      const task = getTask(taskId);
+      if (!task) {
+        json(res, 404, withTimestamp({ error: 'Task not found' }));
+        return true;
+      }
+
+      if (TERMINAL_STATUSES.includes(task.status as TaskStatus)) {
+        json(res, 409, withTimestamp({ error: `Cannot assign workers to ${task.status} task` }));
+        return true;
+      }
+
+      const body = await parseBody(req);
+
+      if (!body.worker_id || typeof body.worker_id !== 'string') {
+        json(res, 400, withTimestamp({ error: 'worker_id is required' }));
+        return true;
+      }
+
+      const role = typeof body.role === 'string' ? body.role : null;
+      const ts = now();
+
+      try {
+        exec(
+          'INSERT INTO orchestrator_task_workers (task_id, worker_id, role, assigned_at) VALUES (?, ?, ?, ?)',
+          taskId, body.worker_id, role, ts,
+        );
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('UNIQUE constraint')) {
+          json(res, 409, withTimestamp({ error: 'Worker already assigned to this task' }));
+          return true;
+        }
+        throw err;
+      }
+
+      log.info('Worker assigned to task', { taskId, workerId: body.worker_id, role });
+      json(res, 201, withTimestamp({ task_id: taskId, worker_id: body.worker_id, role, assigned_at: ts }));
+      return true;
+    }
+
+    // GET /api/orchestrator/tasks/:id — get task detail
+    if (!subpath && method === 'GET') {
+      const task = getTask(taskId);
+      if (!task) {
+        json(res, 404, withTimestamp({ error: 'Task not found' }));
+        return true;
+      }
+
+      const workers = getTaskWorkers(taskId);
+      const activity = getTaskActivity(taskId);
+
+      json(res, 200, withTimestamp({
+        ...task,
+        workers,
+        activity: activity.data,
+        activity_total: activity.total,
+      }));
+      return true;
+    }
+
+    // PUT /api/orchestrator/tasks/:id — update task
+    if (!subpath && method === 'PUT') {
+      const task = getTask(taskId);
+      if (!task) {
+        json(res, 404, withTimestamp({ error: 'Task not found' }));
+        return true;
+      }
+
+      if (TERMINAL_STATUSES.includes(task.status as TaskStatus)) {
+        json(res, 409, withTimestamp({ error: `Cannot update ${task.status} task` }));
+        return true;
+      }
+
+      const body = await parseBody(req);
+      const ts = now();
+      const updates: Record<string, unknown> = { updated_at: ts };
+
+      // Determine the target status and assignee
+      let targetStatus = task.status as TaskStatus;
+      let targetAssignee = task.assignee;
+
+      if (body.status !== undefined) {
+        const newStatus = body.status as TaskStatus;
+        if (!VALID_STATUSES.includes(newStatus)) {
+          json(res, 400, withTimestamp({ error: `invalid status: ${body.status}` }));
+          return true;
+        }
+
+        // Validate transition
+        const allowed = VALID_TRANSITIONS[task.status as TaskStatus];
+        if (!allowed.includes(newStatus)) {
+          json(res, 409, withTimestamp({
+            error: `cannot transition from ${task.status} to ${newStatus}`,
+            allowed_transitions: allowed,
+          }));
+          return true;
+        }
+
+        targetStatus = newStatus;
+        updates.status = newStatus;
+
+        // Set timestamp fields based on status
+        if (newStatus === 'assigned' && !task.assigned_at) {
+          updates.assigned_at = ts;
+        }
+        if (newStatus === 'in_progress' && !task.started_at) {
+          updates.started_at = ts;
+        }
+        if (TERMINAL_STATUSES.includes(newStatus)) {
+          updates.completed_at = ts;
+        }
+
+        // Drift rule: setting status to 'pending' clears assignee
+        if (newStatus === 'pending') {
+          targetAssignee = null;
+          updates.assignee = null;
+        }
+      }
+
+      if (body.assignee !== undefined) {
+        targetAssignee = body.assignee as string | null;
+        updates.assignee = body.assignee;
+        if (body.assignee && !task.assigned_at && !updates.assigned_at) {
+          updates.assigned_at = ts;
+        }
+      }
+
+      if (body.result !== undefined) {
+        updates.result = body.result;
+      }
+      if (body.error !== undefined) {
+        updates.error = body.error;
+      }
+
+      // Validate the final status/assignee combination
+      const validationError = validateStatusAssignee(targetStatus, targetAssignee);
+      if (validationError) {
+        json(res, 400, withTimestamp({ error: validationError }));
+        return true;
+      }
+
+      // Build UPDATE statement
+      const setClauses = Object.keys(updates).map(k => `${k} = ?`).join(', ');
+      const values = Object.values(updates);
+      exec(
+        `UPDATE orchestrator_tasks SET ${setClauses} WHERE id = ?`,
+        ...values, taskId,
+      );
+
+      const updated = getTask(taskId)!;
+      log.info('Task updated', { id: taskId, status: updated.status, assignee: updated.assignee });
+      json(res, 200, withTimestamp(updated));
+      return true;
+    }
+
+    return false;
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message === 'Request body too large') {
+        json(res, 413, withTimestamp({ error: 'Request body too large' }));
+        return true;
+      }
+      if (err.message === 'Invalid JSON') {
+        json(res, 400, withTimestamp({ error: 'Invalid JSON' }));
+        return true;
+      }
+    }
+    throw err;
+  }
+}

--- a/daemon/src/core/migrations/008-task-queue.sql
+++ b/daemon/src/core/migrations/008-task-queue.sql
@@ -1,0 +1,46 @@
+-- Task queue for orchestrator work management.
+-- State machine: pending → assigned → in_progress → completed/failed
+-- Activity log per task for progress tracking.
+
+CREATE TABLE IF NOT EXISTS orchestrator_tasks (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  assignee TEXT,
+  priority INTEGER NOT NULL DEFAULT 0,
+  result TEXT,
+  error TEXT,
+  timeout_seconds INTEGER,
+  created_at TEXT NOT NULL,
+  assigned_at TEXT,
+  started_at TEXT,
+  completed_at TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_orch_tasks_status ON orchestrator_tasks(status);
+CREATE INDEX IF NOT EXISTS idx_orch_tasks_assignee ON orchestrator_tasks(assignee);
+CREATE INDEX IF NOT EXISTS idx_orch_tasks_priority ON orchestrator_tasks(priority);
+CREATE INDEX IF NOT EXISTS idx_orch_tasks_created_at ON orchestrator_tasks(created_at);
+
+CREATE TABLE IF NOT EXISTS orchestrator_task_workers (
+  task_id TEXT NOT NULL REFERENCES orchestrator_tasks(id),
+  worker_id TEXT NOT NULL,
+  role TEXT,
+  assigned_at TEXT NOT NULL,
+  PRIMARY KEY (task_id, worker_id)
+);
+
+CREATE TABLE IF NOT EXISTS orchestrator_task_activity (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  task_id TEXT NOT NULL REFERENCES orchestrator_tasks(id),
+  agent TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'note',
+  stage TEXT,
+  message TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_orch_task_activity_task_id ON orchestrator_task_activity(task_id);
+CREATE INDEX IF NOT EXISTS idx_orch_task_activity_type ON orchestrator_task_activity(type);

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -21,6 +21,7 @@ import { handleTasksRoute } from './api/tasks.js';
 import { handleConfigRoute } from './api/config.js';
 import { handleOrchestratorRoute } from './api/orchestrator.js';
 import { handleTimerRoute, initTimers } from './api/timer.js';
+import { handleTaskQueueRoute } from './api/task-queue.js';
 import {
   getExtension,
   isDegraded,
@@ -189,6 +190,7 @@ const server = http.createServer((req, res) => {
         () => handleAgentsRoute(req, res, url.pathname),
         () => handleOrchestratorRoute(req, res, url.pathname),
         () => handleTimerRoute(req, res, url.pathname),
+        () => handleTaskQueueRoute(req, res, url.pathname, url.searchParams),
         () => handleSendRoute(req, res, url.pathname),
         () => handleStateRoute(req, res, url.pathname, url.searchParams),
         () => handleMessagesRoute(req, res, url.pathname, url.searchParams),


### PR DESCRIPTION
## Summary

Core task queue implementation for orchestrator v2. Includes:

- **orchestrator_tasks / orchestrator_task_workers / orchestrator_task_activity** tables with migration
- Full state machine (`pending → assigned → in_progress → completed/failed`) with validated transitions
- Task CRUD + activity log with pagination + worker assignment API endpoints
- Direct channel support in message router (bypasses scheduler, injects immediately into tmux)
- 63 tests passing

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)