### PR TITLE
Fix duplicate comms notifications for unread messages

### DIFF
--- a/daemon/src/automation/tasks/comms-heartbeat.ts
+++ b/daemon/src/automation/tasks/comms-heartbeat.ts
@@ -11,11 +11,15 @@
  */
 
 import { query, exec } from '../../core/db.js';
-import { injectMessage, listSessions } from '../../agents/tmux.js';
+import { injectMessage, listSessions, _getCommsSession } from '../../agents/tmux.js';
+import { getLastNotificationTime } from './message-delivery.js';
 import { createLogger } from '../../core/logger.js';
 import type { Scheduler } from '../scheduler.js';
 
 const log = createLogger('comms-heartbeat');
+
+/** Skip heartbeat unread-message nudge if message-delivery notified within this window. */
+const DEDUP_WINDOW_MS = 60_000;
 
 interface AgentRow {
   id: string;
@@ -28,10 +32,13 @@ interface MessageCount {
 }
 
 /**
- * Check whether the comms session is alive.
+ * Check whether the comms session (comms1) is alive.
+ * Checks specifically for the comms session name — not just any tmux session —
+ * so a running orchestrator (orch1) doesn't produce a false positive.
  */
 function isCommsAlive(): boolean {
-  return listSessions().length > 0;
+  const commsSession = _getCommsSession();
+  return listSessions().includes(commsSession);
 }
 
 /**
@@ -97,7 +104,13 @@ async function run(): Promise<void> {
   }
 
   const pendingWorkers = getPendingWorkers();
-  const unreadCount = getUnreadMessageCount();
+
+  // Skip unread-message nudge if message-delivery already notified comms recently.
+  // This prevents the agent from receiving both a real-time notification and a
+  // heartbeat nudge for the same unread messages (kithkit #30).
+  const lastMessageNotification = getLastNotificationTime('comms');
+  const recentlyNotified = (Date.now() - lastMessageNotification) < DEDUP_WINDOW_MS;
+  const unreadCount = recentlyNotified ? 0 : getUnreadMessageCount();
 
   if (pendingWorkers.length === 0 && unreadCount === 0) {
     log.debug('Nothing pending — heartbeat silent');

--- a/daemon/src/automation/tasks/message-delivery.ts
+++ b/daemon/src/automation/tasks/message-delivery.ts
@@ -49,7 +49,24 @@ const _retryCounts = new Map<number, number>();
  */
 const _lastPingTime = new Map<number, number>();
 
+/**
+ * Tracks the last time we successfully injected a notification ping into
+ * each persistent agent's tmux session. Used by comms-heartbeat to avoid
+ * duplicate nudges — if message-delivery already notified comms recently,
+ * the heartbeat skips the unread-message portion of its nudge.
+ */
+const _lastAgentNotificationTime = new Map<string, number>();
+
 // ── Public API ───────────────────────────────────────────────
+
+/**
+ * Returns the last time a notification ping was successfully injected into
+ * the given agent's tmux session (epoch ms), or 0 if never.
+ * Used by comms-heartbeat to suppress duplicate unread-message nudges.
+ */
+export function getLastNotificationTime(agentId: string): number {
+  return _lastAgentNotificationTime.get(agentId) ?? 0;
+}
 
 /**
  * Notify the delivery task that a new message was queued.
@@ -208,6 +225,7 @@ async function deliverNewMessages(liveSessions: Set<string>): Promise<{ delivere
           updated_at: now,
         });
       }
+      _lastAgentNotificationTime.set(agentId, nowMs);
       log.debug('Notification ping sent', { to: agentId, count: deliverable.length });
     } else {
       for (const msg of deliverable) {
@@ -281,6 +299,7 @@ async function repingUnreadMessages(liveSessions: Set<string>): Promise<number> 
         const updatedMeta = JSON.stringify({ ...existingMeta, last_notified_at: nowIso });
         exec('UPDATE messages SET metadata = ? WHERE id = ?', updatedMeta, msg.id);
       }
+      _lastAgentNotificationTime.set(agentId, now);
       repinged += messages.length;
       log.debug('Re-ping sent for unread messages', { to: agentId, count: messages.length });
     }
@@ -384,6 +403,7 @@ export function register(scheduler: Scheduler): void {
 export function _resetRetriesForTesting(): void {
   _retryCounts.clear();
   _lastPingTime.clear();
+  _lastAgentNotificationTime.clear();
 }
 
 /** @internal Get current retry count for testing */


### PR DESCRIPTION
## Summary

Fixes #30.

- The heartbeat task and message-delivery task both notified comms about unread messages, causing duplicate nudges within the same second
- Added `getLastNotificationTime()` export to message-delivery so comms-heartbeat can check if a real-time notification was already sent recently
- Heartbeat now skips the unread-message portion of its nudge if message-delivery already notified comms within the last 60s
- Also fixes `isCommsAlive()` to check specifically for the comms session (comms1) rather than any tmux session, preventing false positives when only the orchestrator is running

## Changes

- `daemon/src/automation/tasks/message-delivery.ts`: Added `_lastAgentNotificationTime` map + `getLastNotificationTime()` export; updated delivery and re-ping paths to record notification timestamps
- `daemon/src/automation/tasks/comms-heartbeat.ts`: Import dedup helpers; add 60s dedup window check before querying unread messages; fix `isCommsAlive()` to use `_getCommsSession()`

## Test plan

- [ ] Verify only one notification appears when a message arrives during a heartbeat cycle
- [ ] Verify heartbeat still reports unread messages if no real-time notification was sent (e.g., message-delivery was delayed)
- [ ] Verify `isCommsAlive()` returns false when only orchestrator session is running

Cherry-picked from KKit-BMO commit ad13c0f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)