### PR TITLE
Fix access control to use contacts DB for sender classification

### DIFF
--- a/daemon/src/core/access-control.ts
+++ b/daemon/src/core/access-control.ts
@@ -4,9 +4,15 @@
  * Framework provides 3 base tiers: Safe, Unknown, Blocked.
  * Extensions can register additional tiers via registerTier().
  * Rate limits are enforced per tier with configurable windows.
+ *
+ * Safe/blocked senders are resolved from both config and the contacts
+ * table (contacts tagged with tier:safe or tier:blocked). The contacts
+ * table is checked when a sender isn't found in the config-based sets,
+ * giving the DB a fallback role that works without any extension code.
  */
 
 import { createLogger } from './logger.js';
+import { getDatabase } from './db.js';
 
 const log = createLogger('access-control');
 
@@ -84,11 +90,42 @@ export function registerTier(name: string, classifier: TierClassifier): void {
   log.info(`Registered custom tier classifier: ${name}`);
 }
 
+// ── Contacts DB lookup ──────────────────────────────────────
+
+/**
+ * Check the contacts table for a sender's tier tag.
+ * Looks up by telegram_id or email, returns the first tier:* tag found.
+ * Returns null if no matching contact or no tier tag.
+ */
+function checkContactsTier(senderId: string): string | null {
+  try {
+    const db = getDatabase();
+    const row = db.prepare(
+      "SELECT tags, role FROM contacts WHERE telegram_id = ? OR email LIKE ? LIMIT 1"
+    ).get(senderId, `%${senderId}%`) as { tags: string; role: string | null } | undefined;
+    if (!row) return null;
+
+    // Owner role implies safe
+    if (row.role === 'owner') return SenderTier.Safe;
+
+    let tags: string[] = [];
+    try { tags = JSON.parse(row.tags); } catch { /* ignore */ }
+
+    if (tags.includes('tier:blocked')) return SenderTier.Blocked;
+    if (tags.includes('tier:safe')) return SenderTier.Safe;
+    return null;
+  } catch {
+    // DB not available (e.g., during tests or early init) — skip silently
+    return null;
+  }
+}
+
 // ── Classification ──────────────────────────────────────────
 
 /**
  * Classify a sender into a tier.
- * Custom classifiers are checked first, then default rules.
+ * Custom classifiers are checked first, then config-based sets,
+ * then the contacts table as a fallback.
  */
 export function classifySender(senderId: string): string {
   // Check custom classifiers first (extensions)
@@ -97,9 +134,14 @@ export function classifySender(senderId: string): string {
     if (result !== null) return result;
   }
 
-  // Default classification
+  // Config-based classification
   if (_blockedSenders.has(senderId)) return SenderTier.Blocked;
   if (_safeSenders.has(senderId)) return SenderTier.Safe;
+
+  // Contacts DB fallback — check for tier tags on matching contacts
+  const contactTier = checkContactsTier(senderId);
+  if (contactTier !== null) return contactTier;
+
   return SenderTier.Unknown;
 }
 


### PR DESCRIPTION
## Summary
- `classifySender()` now falls back to the contacts table when a sender isn't in the config-based safe/blocked sets
- Contacts with `tier:safe` tag or `owner` role → classified as safe
- Contacts with `tier:blocked` tag → classified as blocked
- Eliminates dependency on flat-file `safe-senders.json` — the contacts table (added in #33) is the single source of truth

## Context
The contacts system was added in #33 but the core access control engine still only checked the in-memory config-based sets. Extensions had to implement their own DB lookup (e.g., BMO's Telegram adapter was reading from a now-deleted `safe-senders.json`). This change makes the contacts-based classification work at the framework level.

## Test plan
- [x] All 16 existing access control tests pass (DB lookup degrades gracefully when no DB available)
- [ ] Manual: add a contact with `tier:safe` tag and verify they're classified as safe without config changes
- [ ] Manual: add a contact with `owner` role and verify they're classified as safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)