### PR TITLE
Add integration skill to core

### DIFF
--- a/.claude/skills/integration/SKILL.md
+++ b/.claude/skills/integration/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: integration
+description: Build integrations on the Kithkit agent framework. Covers the extension system, daemon API, scheduler, channel router, and memory system. Use when adding new capabilities (Telegram, email, voice, browser, GitHub) to a Kithkit-managed agent.
+user-invocable: false
+---
+
+# Kithkit Integration
+
+Build integrations on the Kithkit agent framework. This skill covers the extension system, daemon API, scheduler, channel router, and memory system — everything needed to add new capabilities to a Kithkit-managed agent.
+
+## Architecture
+
+Kithkit uses a three-tier architecture:
+
+```
+Human <-> Comms Agent <-> Daemon <-> Workers
+              |            |
+          Identity      SQLite DB
+```
+
+- **Comms agent** — persistent Claude Code session, human-facing interface
+- **Daemon** — Node.js server on localhost:3847, manages all state
+- **Workers** — ephemeral Claude Code agents spawned for specific tasks
+
+All persistent state (todos, calendar, memories, messages, config) lives in SQLite via the daemon API. Extensions add custom routes, scheduler tasks, and health checks without modifying the framework.
+
+## Writing Extensions
+
+An extension is a TypeScript module implementing the `Extension` interface:
+
+```typescript
+import type { Extension } from 'kithkit/daemon';
+
+export default {
+  name: 'my-extension',
+
+  async onInit(config, server) {
+    // Register routes, tasks, adapters
+  },
+
+  async onRoute(req, res, pathname, searchParams) {
+    // Handle custom HTTP endpoints (optional)
+    return false;
+  },
+
+  async onShutdown() {
+    // Clean up resources
+  },
+} satisfies Extension;
+```
+
+Register in your daemon entry point before starting:
+
+```typescript
+import { registerExtension } from 'kithkit/daemon';
+import myExtension from '../extensions/my-extension/index.js';
+registerExtension(myExtension);
+import 'kithkit/daemon/main.js';
+```
+
+Only one extension per daemon instance. Aggregate sub-modules internally.
+
+### Custom Routes
+
+```typescript
+import { registerRoute } from 'kithkit/daemon/core/route-registry';
+
+registerRoute('/my-ext/status', async (req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ status: 'ok' }));
+  return true;
+});
+```
+
+Pattern types: exact path (`'/my-ext/status'`) or prefix wildcard (`'/my-ext/*'`).
+
+### Scheduler Tasks
+
+Step 1 — Add to `kithkit.config.yaml`:
+
+```yaml
+scheduler:
+  tasks:
+    - name: my-task
+      interval: "1h"
+      enabled: true
+      config:
+        requires_session: false
+```
+
+Step 2 — Register handler in `onInit`:
+
+```typescript
+const handler: TaskHandler = async ({ taskName, config }) => {
+  // Task logic
+};
+scheduler.registerHandler('my-task', handler);
+```
+
+Task flags: `requires_session: true` (skip when no tmux session), `idle_only: true` (skip when agent is active).
+
+Manual trigger: `curl -X POST http://localhost:3847/api/tasks/my-task/run`
+
+### Health Checks
+
+```typescript
+import { registerCheck } from 'kithkit/daemon/core/extended-status';
+
+registerCheck('my-service', async () => ({
+  ok: true,
+  message: 'Service reachable',
+}));
+```
+
+Checks run on `GET /health/extended`. Any `ok: false` sets overall status to `"degraded"`.
+
+### Config Type Augmentation
+
+```typescript
+declare module 'kithkit/daemon/core/config' {
+  interface KithkitConfig {
+    my_extension?: { api_url: string; timeout_ms?: number };
+  }
+}
+```
+
+### Degraded Mode
+
+If `onInit` throws, the daemon continues with the extension disabled. Core API remains available.
+
+## Daemon API Quick Reference
+
+All endpoints are on `localhost:3847`. JSON responses include `timestamp` (ISO 8601).
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/health` | GET | Health check |
+| `/health/extended` | GET | All health checks + operational status |
+| `/status` | GET | Quick status |
+| `/api/agents/spawn` | POST | Spawn worker (`{profile, prompt}`) |
+| `/api/agents` | GET | List agents |
+| `/api/agents/:id/status` | GET | Agent/job status with token usage |
+| `/api/agents/:id` | DELETE | Kill worker |
+| `/api/todos` | GET/POST | List/create todos |
+| `/api/todos/:id` | GET/PUT/DELETE | CRUD a todo |
+| `/api/calendar` | GET/POST | List/create events |
+| `/api/calendar/:id` | GET/PUT/DELETE | CRUD an event |
+| `/api/messages` | GET/POST | Message history / send inter-agent message |
+| `/api/send` | POST | Deliver via channel router (`{message, channels}`) |
+| `/api/memory/store` | POST | Store memory (`{content, type, tags}`) |
+| `/api/memory/search` | POST | Search (`{query, mode, tags}`) |
+| `/api/config/:key` | GET/PUT | Config KV store |
+| `/api/config/reload` | POST | Hot-reload config from disk |
+| `/api/tasks` | GET | List scheduler tasks |
+| `/api/tasks/:name/run` | POST | Manual trigger |
+| `/api/usage` | GET | Token/cost stats |
+
+See `reference.md` for full request/response details.
+
+## Channel Router
+
+Deliver messages to users through configured channels:
+
+```bash
+curl -X POST http://localhost:3847/api/send \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hello", "channels": ["telegram"]}'
+```
+
+Omit `channels` to send to all active channels. Channel adapters are registered by extensions.
+
+## Memory System
+
+Three search modes — keyword (AND matching), vector (semantic similarity via embeddings), and hybrid:
+
+```bash
+# Store
+curl -X POST http://localhost:3847/api/memory/store \
+  -H "Content-Type: application/json" \
+  -d '{"content": "User prefers dark mode", "type": "fact", "tags": ["preferences"]}'
+
+# Search
+curl -X POST http://localhost:3847/api/memory/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "user preferences", "mode": "keyword"}'
+```
+
+Types: `fact`, `episodic`, `procedural`. Vector search requires sqlite-vec and ONNX embeddings.
+
+## Recipes
+
+This skill includes integration recipes as reference files in the `recipes/` directory:
+
+| Recipe | File | What it covers |
+|--------|------|---------------|
+| Telegram Bot | `recipes/telegram.md` | Bot setup, webhook/polling, sender classification, media |
+| Microsoft Graph Email | `recipes/graph-email.md` | Azure AD app, client credentials OAuth, full mailbox access |
+| Outlook IMAP | `recipes/outlook-imap.md` | Separate Azure app, device code flow, Python IMAP adapter |
+| Himalaya CLI Email | `recipes/himalaya-email.md` | CLI email client, Gmail/IMAP, multi-account |
+| JMAP Email (Fastmail) | `recipes/jmap-email.md` | RFC 8620 JMAP protocol, batched method calls |
+| Email Triage Task | `recipes/email-check-task.md` | Scheduled triage, pattern matching, sub-agent classification |
+| Voice Overview | `recipes/voice-integration.md` | Architecture, setup checklist, component order |
+| Voice Client | `recipes/voice-client.md` | macOS menu bar app, audio capture, wake word, playback |
+| Voice STT | `recipes/voice-stt.md` | Whisper-cpp, on-device transcription |
+| Voice TTS | `recipes/voice-tts.md` | Kokoro-ONNX, Python microservice, daemon lifecycle |
+| Browserbase | `recipes/browserbase.md` | Cloud browser automation, sidecar, hand-off |
+| GitHub Rate Limiting | `recipes/github-rate-limiting.md` | Claude Code hooks, write rate limits, ledger |
+
+Each recipe includes prerequisites, setup steps, config snippets, reference code, and troubleshooting.

--- a/.claude/skills/integration/recipes/browserbase.md
+++ b/.claude/skills/integration/recipes/browserbase.md
@@ -1,0 +1,145 @@
+# Browser Automation (Browserbase Cloud)
+
+Cloud browser automation with built-in human hand-off support. The daemon spawns a sidecar process on port 3849 that manages Browserbase SDK sessions, Playwright CDP connections, and live view URLs for hand-off to a human.
+
+## Prerequisites
+
+- Browserbase account with an API key and project ID
+- Node.js 22+
+- `@browserbasehq/sdk` and `playwright-core` npm packages
+
+## Setup
+
+```bash
+# Store credentials in macOS Keychain (never in config files)
+security add-generic-password -s credential-browserbase-api-key -a bmo -w "<your-api-key>"
+security add-generic-password -s credential-browserbase-project-id -a bmo -w "<your-project-id>"
+
+# Install dependencies in the daemon workspace
+cd /path/to/kithkit-daemon
+npm install @browserbasehq/sdk playwright-core
+
+# Enable in config (see snippet below), then reload
+curl -s -X POST http://localhost:3847/api/config/reload
+```
+
+## Config Snippet
+
+```yaml
+integrations:
+  browserbase:
+    enabled: true
+    sidecar:
+      port: 3849
+      startup_timeout_ms: 15000
+    credentials:
+      api_key_secret: credential-browserbase-api-key      # Keychain secret name
+      project_id_secret: credential-browserbase-project-id
+    session:
+      default_timeout_ms: 300000   # 5 min session TTL
+      keep_alive: false            # set true during development
+    handoff:
+      enabled: true
+      live_view_ttl_ms: 600000     # 10 min live view link lifetime
+```
+
+## Architecture
+
+```
+Daemon
+  └── browser-sidecar (port 3849)
+        ├── Browserbase SDK  ──── Browserbase Cloud
+        ├── Playwright CDP   ──── Remote browser instance
+        ├── Context store    ──── per-session state (cookies, storage)
+        └── Hand-off infra   ──── live view URLs → human
+```
+
+The daemon starts the sidecar on first use and keeps it running. The sidecar is stateful — it maintains a map of active sessions and their Playwright page references. All browser commands go through the sidecar HTTP API; the daemon never calls Browserbase directly.
+
+## Sidecar Endpoints
+
+All endpoints are on `http://127.0.0.1:3849`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/session/create` | Create a new Browserbase session, returns `sessionId` and `liveViewUrl` |
+| `POST` | `/session/navigate` | Navigate to URL — body: `{ sessionId, url }` |
+| `POST` | `/session/click` | Click an element — body: `{ sessionId, selector }` |
+| `POST` | `/session/type` | Type into an input — body: `{ sessionId, selector, text }` |
+| `POST` | `/session/screenshot` | Returns PNG as base64 — body: `{ sessionId }` |
+| `DELETE` | `/session/destroy` | End and release a session — body: `{ sessionId }` |
+| `GET` | `/session/live-url` | Get live view URL for a session — query: `?sessionId=...` |
+| `GET` | `/health` | Sidecar health check |
+
+### Example: Create Session and Navigate
+
+```bash
+# Create session
+curl -s -X POST http://localhost:3849/session/create \
+  -H "Content-Type: application/json" \
+  -d '{}' | jq .
+
+# Response:
+# { "sessionId": "sess_abc123", "liveViewUrl": "https://www.browserbase.com/sessions/sess_abc123" }
+
+# Navigate
+curl -s -X POST http://localhost:3849/session/navigate \
+  -H "Content-Type: application/json" \
+  -d '{"sessionId": "sess_abc123", "url": "https://example.com"}'
+
+# Take screenshot
+curl -s -X POST http://localhost:3849/session/screenshot \
+  -H "Content-Type: application/json" \
+  -d '{"sessionId": "sess_abc123"}' | jq -r .screenshot | base64 -d > shot.png
+```
+
+### Hand-off Flow
+
+When a task requires human interaction (CAPTCHA, MFA, approval):
+
+1. Worker requests live view URL via `GET /session/live-url?sessionId=...`
+2. Worker sends URL to human via `POST /api/send` with `channels: ["telegram"]`
+3. Human completes the action in the live browser
+4. Worker polls for completion (element present, URL changed, etc.) or waits for human confirmation
+5. Worker resumes automation
+
+```typescript
+// Example hand-off in a worker
+const { liveViewUrl } = await fetch('http://localhost:3849/session/live-url?sessionId=' + sessionId)
+  .then(r => r.json());
+
+await fetch('http://localhost:3847/api/send', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    message: `I need you to complete a CAPTCHA. Open this link:\n${liveViewUrl}`,
+    channels: ['telegram'],
+  }),
+});
+
+// Wait for human to confirm via a todo or message check
+```
+
+## Troubleshooting
+
+**Sidecar fails to start**
+Check that `@browserbasehq/sdk` and `playwright-core` are installed in the daemon's `node_modules`. The sidecar script path must be absolute. Check daemon logs for the spawn error. Also verify port 3849 is not in use:
+```bash
+lsof -i :3849
+```
+
+**401 on session create**
+The API key loaded from Keychain is wrong or stale. Retrieve and verify:
+```bash
+security find-generic-password -s credential-browserbase-api-key -w
+```
+Update via `security add-generic-password -U ...` with the `-U` (update) flag.
+
+**CDP connection fails**
+Browserbase returns a `connectUrl` for Playwright CDP. If the connection fails immediately, the Browserbase session may have already expired (they have a short idle TTL). Ensure you call navigate within a few seconds of creating the session, or set `keep_alive: true` in config during development.
+
+**Live view URL unavailable**
+The live view URL is generated at session creation time. If `GET /session/live-url` returns 404, the `sessionId` is not in the sidecar's active session map — either it was never created in this sidecar process or the sidecar restarted. Re-create the session.
+
+**Hand-off timeout**
+If the human does not act within the live view TTL (`live_view_ttl_ms`), the Browserbase session may expire. Build your hand-off flow with an explicit timeout: if no completion signal arrives within N minutes, destroy the session and report failure back to the orchestrator so it can inform the human.

--- a/.claude/skills/integration/recipes/email-check-task.md
+++ b/.claude/skills/integration/recipes/email-check-task.md
@@ -1,0 +1,401 @@
+# Periodic Email Triage Task
+
+Automatically triage incoming email on a schedule. Pattern rules handle known senders immediately; a Claude sub-agent classifies anything that doesn't match, choosing from a closed action set to keep costs predictable.
+
+---
+
+## Overview
+
+```
+Scheduler fires
+    |
+    v
+fetchUnread() ──> for each email:
+    |                 matchesAny(rules) ──yes──> apply action (mark_read / file / notify / ignore)
+    |                       |
+    |                      no
+    |                       v
+    |               sub-agent classify(email)
+    |                       |
+    |                       v
+    |               action: notify | add_rule | file | ignore
+    v
+notify comms if any actionable emails
+```
+
+---
+
+## Prerequisites
+
+- Email provider configured (JMAP or IMAP — see companion recipes)
+- Daemon running and healthy (`GET /health`)
+- `ANTHROPIC_API_KEY` available to the daemon process
+- Scheduler enabled in config (`scheduler.enabled: true`)
+
+---
+
+## Setup
+
+### 1. Configure Triage Rules
+
+Add rules to your config (see Config Snippet below). Rules are evaluated top-to-bottom; first match wins.
+
+### 2. Register the Task Handler
+
+Create `daemon/src/automation/tasks/email-triage.ts` (see Reference Code below) and import it in your extension's `onInit`:
+
+```typescript
+import { registerEmailTriageTask } from './tasks/email-triage.js';
+
+export async function onInit(daemon: DaemonContext) {
+  registerEmailTriageTask(daemon);
+}
+```
+
+### 3. Enable the Scheduler Task
+
+Add the task entry to your config (see Config Snippet). Then hot-reload:
+
+```bash
+curl -s -X POST http://localhost:3847/api/config/reload
+```
+
+Verify it appeared:
+
+```bash
+curl -s http://localhost:3847/api/tasks | jq '.[] | select(.name=="email-triage")'
+```
+
+Trigger manually to test:
+
+```bash
+curl -s -X POST http://localhost:3847/api/tasks/email-triage/run
+```
+
+---
+
+## Config Snippet
+
+```yaml
+email:
+  provider:
+    type: jmap
+    session_url: https://api.fastmail.com/.well-known/jmap
+    credential_name: credential-jmap-api-token
+
+  triage:
+    rules:
+      # VIP senders — always notify comms immediately
+      - name: vip
+        action: notify
+        from_contains:
+          - "dave@"
+          - "r2@"
+          - "boss@example.com"
+
+      # Confirmed junk — mark read, file to Junk, no notification
+      - name: junk
+        action: mark_read_and_file
+        destination: Junk
+        subject_contains:
+          - "unsubscribe"
+          - "DEAL OF THE DAY"
+        from_contains:
+          - "noreply@promotions."
+          - "@marketing."
+
+      # Newsletters — mark read, file, no notification
+      - name: newsletters
+        action: mark_read_and_file
+        destination: Newsletters
+        subject_regex:
+          - "^\\[.*\\]"            # [List Name] Subject format
+        from_contains:
+          - "newsletter@"
+          - "digest@"
+
+      # Receipts and order confirmations — mark read, file
+      - name: receipts
+        action: mark_read_and_file
+        destination: Receipts
+        subject_contains:
+          - "Your order"
+          - "Receipt from"
+          - "Invoice #"
+          - "Your receipt"
+
+      # Mark-read-only for known automated senders
+      - name: auto_read
+        action: mark_read
+        from_contains:
+          - "no-reply@github.com"
+          - "notifications@github.com"
+
+scheduler:
+  tasks:
+    - name: email-triage
+      enabled: true
+      interval: 300000    # every 5 minutes (ms)
+      config:
+        mailbox: Inbox
+        limit: 50          # emails per run
+        sub_agent_enabled: true
+        sub_agent_model: claude-haiku-4-5   # cheap model for classification
+        sub_agent_max_tokens: 256
+        notify_channel: telegram
+```
+
+---
+
+## Reference Code
+
+### matchesAny — Pattern Matcher
+
+```typescript
+interface TriageRule {
+  name: string;
+  action: 'notify' | 'mark_read' | 'mark_read_and_file' | 'ignore';
+  destination?: string;      // for mark_read_and_file
+  from_contains?: string[];
+  subject_contains?: string[];
+  subject_regex?: string[];
+}
+
+interface EmailSummary {
+  id: string;
+  subject: string;
+  from: Array<{ email: string; name?: string }>;
+  preview: string;
+  receivedAt: string;
+}
+
+function matchesAny(email: EmailSummary, rules: TriageRule[]): TriageRule | null {
+  const fromAddrs = email.from.map(f => f.email.toLowerCase());
+  const subject = (email.subject ?? '').toLowerCase();
+
+  for (const rule of rules) {
+    // from_contains: any sender address substring match
+    if (rule.from_contains?.length) {
+      const hit = rule.from_contains.some(pattern =>
+        fromAddrs.some(addr => addr.includes(pattern.toLowerCase()))
+      );
+      if (hit) return rule;
+    }
+
+    // subject_contains: substring match
+    if (rule.subject_contains?.length) {
+      const hit = rule.subject_contains.some(pattern =>
+        subject.includes(pattern.toLowerCase())
+      );
+      if (hit) return rule;
+    }
+
+    // subject_regex: full regex match
+    if (rule.subject_regex?.length) {
+      const hit = rule.subject_regex.some(pattern =>
+        new RegExp(pattern, 'i').test(email.subject ?? '')
+      );
+      if (hit) return rule;
+    }
+  }
+
+  return null;
+}
+```
+
+### Task Handler
+
+```typescript
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export function registerEmailTriageTask(daemon: DaemonContext) {
+  daemon.scheduler.register('email-triage', async (taskConfig) => {
+    const cfg = taskConfig as {
+      mailbox: string;
+      limit: number;
+      sub_agent_enabled: boolean;
+      sub_agent_model: string;
+      sub_agent_max_tokens: number;
+      notify_channel: string;
+    };
+
+    const provider = daemon.email.getProvider();
+    const rules: TriageRule[] = daemon.config.email?.triage?.rules ?? [];
+    const emails = await provider.fetchUnread(cfg.mailbox, cfg.limit);
+
+    const notifications: string[] = [];
+
+    for (const email of emails) {
+      const rule = matchesAny(email, rules);
+
+      if (rule) {
+        await applyRule(provider, email, rule);
+        if (rule.action === 'notify') {
+          notifications.push(formatNotification(email));
+        }
+      } else if (cfg.sub_agent_enabled) {
+        const action = await classifyWithSubAgent(email, cfg);
+        await handleSubAgentAction(provider, daemon, email, action, rules, notifications);
+      }
+    }
+
+    if (notifications.length > 0) {
+      await daemon.send({
+        to: 'comms',
+        type: 'email-triage-result',
+        body: notifications.join('\n\n'),
+        channels: [cfg.notify_channel],
+      });
+    }
+  });
+}
+
+async function applyRule(
+  provider: EmailProvider,
+  email: EmailSummary,
+  rule: TriageRule
+): Promise<void> {
+  switch (rule.action) {
+    case 'mark_read':
+      await provider.markAsRead(email.id);
+      break;
+    case 'mark_read_and_file':
+      await provider.markAsRead(email.id);
+      if (rule.destination) await provider.moveEmail(email.id, rule.destination);
+      break;
+    case 'notify':
+      // notification is collected by caller
+      break;
+    case 'ignore':
+    default:
+      break;
+  }
+}
+
+function formatNotification(email: EmailSummary): string {
+  const from = email.from[0];
+  const sender = from.name ? `${from.name} <${from.email}>` : from.email;
+  return `**New email** from ${sender}\nSubject: ${email.subject}\n${email.preview}`;
+}
+```
+
+### Sub-Agent Classification Prompt
+
+```typescript
+const SUB_AGENT_PROMPT = `You are an email triage assistant. Classify this email and return a single JSON object.
+
+Allowed actions (pick exactly one):
+- "notify"    — this needs the user's attention (reply expected, important info, time-sensitive)
+- "add_rule"  — this is a recurring pattern; suggest a new triage rule to handle it automatically
+- "file"      — archive it silently (no reply needed, not urgent)
+- "ignore"    — leave it in the inbox unread (uncertain, borderline)
+
+Return ONLY valid JSON, no prose:
+{
+  "action": "<notify|add_rule|file|ignore>",
+  "reason": "<one sentence>",
+  "rule"?: {                          // only when action is "add_rule"
+    "name": "<short-identifier>",
+    "from_contains"?: ["<pattern>"],
+    "subject_contains"?: ["<pattern>"],
+    "action": "<mark_read|mark_read_and_file|ignore>",
+    "destination"?: "<MailboxName>"   // required for mark_read_and_file
+  },
+  "destination"?: "<MailboxName>"     // for action "file" — defaults to "Archive"
+}
+
+Email:
+From: {{FROM}}
+Subject: {{SUBJECT}}
+Preview: {{PREVIEW}}`;
+
+async function classifyWithSubAgent(
+  email: EmailSummary,
+  cfg: { sub_agent_model: string; sub_agent_max_tokens: number }
+): Promise<SubAgentResult> {
+  const prompt = SUB_AGENT_PROMPT
+    .replace('{{FROM}}', email.from.map(f => `${f.name ?? ''} <${f.email}>`).join(', '))
+    .replace('{{SUBJECT}}', email.subject ?? '(no subject)')
+    .replace('{{PREVIEW}}', email.preview?.slice(0, 300) ?? '');
+
+  try {
+    const { stdout } = await execFileAsync('curl', [
+      '-sf',
+      '-X', 'POST',
+      '-H', 'Content-Type: application/json',
+      '-H', `Authorization: Bearer ${process.env.ANTHROPIC_API_KEY}`,
+      '-d', JSON.stringify({
+        model: cfg.sub_agent_model,
+        max_tokens: cfg.sub_agent_max_tokens,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+      'https://api.anthropic.com/v1/messages',
+    ]);
+
+    const resp = JSON.parse(stdout);
+    const text = resp.content?.[0]?.text ?? '{}';
+    return JSON.parse(text) as SubAgentResult;
+  } catch {
+    // On any parse/API error, default to ignore
+    return { action: 'ignore', reason: 'classification failed' };
+  }
+}
+
+interface SubAgentResult {
+  action: 'notify' | 'add_rule' | 'file' | 'ignore';
+  reason: string;
+  rule?: TriageRule;
+  destination?: string;
+}
+
+async function handleSubAgentAction(
+  provider: EmailProvider,
+  daemon: DaemonContext,
+  email: EmailSummary,
+  result: SubAgentResult,
+  rules: TriageRule[],
+  notifications: string[]
+): Promise<void> {
+  switch (result.action) {
+    case 'notify':
+      notifications.push(formatNotification(email));
+      break;
+
+    case 'add_rule':
+      if (result.rule) {
+        // Persist the new rule via daemon config API
+        await daemon.config.appendEmailTriageRule(result.rule);
+        // Apply the new rule immediately to this email
+        await applyRule(provider, email, result.rule);
+        daemon.logger.info('email-triage', `Added rule: ${result.rule.name}`);
+      }
+      break;
+
+    case 'file':
+      await provider.markAsRead(email.id);
+      await provider.moveEmail(email.id, result.destination ?? 'Archive');
+      break;
+
+    case 'ignore':
+    default:
+      break;
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Emails not being checked | Scheduler task not registered or not enabled | Check `GET /api/tasks`; confirm `email-triage` appears with `enabled: true`. Verify `registerEmailTriageTask()` is called in `onInit`. |
+| Rules not matching | Pattern case sensitivity or whitespace | `from_contains` is lowercased before comparison; `subject_regex` uses `i` flag. Log `email.from` and `email.subject` raw to verify. |
+| Sub-agent API errors | Missing or invalid `ANTHROPIC_API_KEY` | Confirm env var is set in daemon's launchd plist. Check daemon logs for `curl` stderr. |
+| Double notifications | Task fired twice in one interval | Check for duplicate task registrations. Each `scheduler.register(name)` call overwrites the previous, but two `onInit` calls will double-fire. |
+| High API costs | Sub-agent classifying too many emails | Expand your rules to catch recurring senders before they hit the sub-agent. Check `GET /api/usage`. Use `claude-haiku-4-5` not Sonnet/Opus for classification. |
+| `add_rule` suggestions ignored | `daemon.config.appendEmailTriageRule` not implemented | Wire up a config mutation endpoint or write the rule back to `kithkit.config.yaml` and call `POST /api/config/reload`. |
+| Task runs but does nothing | `fetchUnread` returns 0 | Confirm the mailbox name in config matches the server exactly (case-sensitive). Manually call `provider.fetchUnread('Inbox', 5)` in a test script. |

--- a/.claude/skills/integration/recipes/github-rate-limiting.md
+++ b/.claude/skills/integration/recipes/github-rate-limiting.md
@@ -1,0 +1,306 @@
+# GitHub Rate Limiting Hooks
+
+Prevent bulk GitHub write operations (PR creation, issue filing) by Claude Code agents using PreToolUse and PostToolUse hooks. The hooks maintain a rolling ledger of writes and block new ones when the hourly limit is reached.
+
+## Prerequisites
+
+- Claude Code with hooks support
+- Python 3.8+
+- `gh` CLI authenticated
+
+## Setup
+
+```bash
+# 1. Create the hooks directory and state directory
+mkdir -p ~/.config/kithkit/hooks
+mkdir -p ~/.local/share/kithkit/github-rate
+
+# 2. Copy hook scripts (paths below must be absolute)
+cp github-rate-check.py  ~/.config/kithkit/hooks/github-rate-check.py
+cp github-rate-log.py    ~/.config/kithkit/hooks/github-rate-log.py
+chmod +x ~/.config/kithkit/hooks/github-rate-check.py
+chmod +x ~/.config/kithkit/hooks/github-rate-log.py
+
+# 3. Initialize the ledger file
+echo '{"entries":[]}' > ~/.local/share/kithkit/github-rate/ledger.json
+
+# 4. Register hooks in .claude/settings.json (see snippet below)
+
+# 5. Test: trigger a deny by temporarily setting MAX_WRITES_PER_HOUR=0
+MAX_WRITES_PER_HOUR=0 python3 ~/.config/kithkit/hooks/github-rate-check.py <<'EOF'
+{"tool": "Bash", "input": {"command": "gh pr create --title test --body test"}}
+EOF
+```
+
+## Hook Registration
+
+Add to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /Users/bmo/.config/kithkit/hooks/github-rate-check.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /Users/bmo/.config/kithkit/hooks/github-rate-log.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Note: the matcher is `"Bash"` with a capital B — it matches the tool name, not the shell command.
+
+## Ledger Format
+
+```json
+{
+  "entries": [
+    {
+      "timestamp": "2026-02-25T14:32:00Z",
+      "action": "gh pr create",
+      "repo": "RockaRhymeLLC/KKit-BMO",
+      "agent": "worker-abc123"
+    }
+  ]
+}
+```
+
+Entries older than 24 hours are pruned by `github-rate-log.py` on every write. The rolling 1-hour window check in `github-rate-check.py` only counts entries within the last 60 minutes.
+
+## Reference Code: github-rate-check.py (PreToolUse)
+
+```python
+#!/usr/bin/env python3
+"""
+PreToolUse hook — blocks gh pr create / gh issue create when hourly limit is reached.
+Claude Code passes hook input as JSON on stdin; output JSON is read for permissionDecision.
+"""
+import sys
+import json
+import os
+import re
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+MAX_WRITES_PER_HOUR = int(os.environ.get('MAX_WRITES_PER_HOUR', '3'))
+STATE_DIR = Path(os.environ.get('STATE_DIR', os.path.expanduser('~/.local/share/kithkit/github-rate')))
+LEDGER_PATH = STATE_DIR / 'ledger.json'
+
+# Repos under these orgs are exempt from the rate limit
+OUR_ORGS = {'RockaRhymeLLC', 'bmo-internal'}
+
+# Patterns that constitute a GitHub write operation
+WRITE_PATTERNS = [
+    re.compile(r'\bgh\s+pr\s+create\b'),
+    re.compile(r'\bgh\s+issue\s+create\b'),
+]
+
+
+def is_write_command(command: str) -> bool:
+    return any(p.search(command) for p in WRITE_PATTERNS)
+
+
+def extract_repo(command: str) -> str | None:
+    """Best-effort repo extraction from --repo flag or gh context."""
+    m = re.search(r'--repo\s+([^\s]+)', command)
+    return m.group(1) if m else None
+
+
+def is_exempt(repo: str | None) -> bool:
+    """Our own org repos are exempt — we trust ourselves."""
+    if not repo:
+        return False
+    org = repo.split('/')[0]
+    return org in OUR_ORGS
+
+
+def count_recent_writes(entries: list, window_minutes: int = 60) -> int:
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
+    return sum(
+        1 for e in entries
+        if datetime.fromisoformat(e['timestamp']) > cutoff
+    )
+
+
+def main():
+    payload = json.loads(sys.stdin.read())
+
+    # Only inspect Bash tool calls
+    if payload.get('tool') != 'Bash':
+        print(json.dumps({}))
+        return
+
+    command = payload.get('input', {}).get('command', '')
+
+    if not is_write_command(command):
+        print(json.dumps({}))
+        return
+
+    # Override env var allows a single explicit bypass
+    if os.environ.get('GITHUB_RATE_OVERRIDE') == '1':
+        print(json.dumps({}))
+        return
+
+    repo = extract_repo(command)
+    if is_exempt(repo):
+        print(json.dumps({}))
+        return
+
+    # Load ledger and count recent writes
+    try:
+        ledger = json.loads(LEDGER_PATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        ledger = {'entries': []}
+
+    recent = count_recent_writes(ledger['entries'])
+
+    if recent >= MAX_WRITES_PER_HOUR:
+        print(json.dumps({
+            'permissionDecision': 'deny',
+            'denyReason': (
+                f'GitHub rate limit reached: {recent}/{MAX_WRITES_PER_HOUR} writes in the last hour. '
+                f'Set GITHUB_RATE_OVERRIDE=1 to bypass, or wait for the window to roll over.'
+            ),
+        }))
+    else:
+        print(json.dumps({}))
+
+
+if __name__ == '__main__':
+    main()
+```
+
+## Reference Code: github-rate-log.py (PostToolUse)
+
+```python
+#!/usr/bin/env python3
+"""
+PostToolUse hook — logs successful gh pr/issue create commands to the ledger.
+Prunes entries older than 24 hours on every write.
+"""
+import sys
+import json
+import os
+import re
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+STATE_DIR = Path(os.environ.get('STATE_DIR', os.path.expanduser('~/.local/share/kithkit/github-rate')))
+LEDGER_PATH = STATE_DIR / 'ledger.json'
+PRUNE_AFTER_HOURS = 24
+
+WRITE_PATTERNS = [
+    re.compile(r'\bgh\s+pr\s+create\b'),
+    re.compile(r'\bgh\s+issue\s+create\b'),
+]
+
+
+def extract_repo(command: str) -> str | None:
+    m = re.search(r'--repo\s+([^\s]+)', command)
+    return m.group(1) if m else None
+
+
+def extract_action(command: str) -> str:
+    if re.search(r'\bgh\s+pr\s+create\b', command):
+        return 'gh pr create'
+    if re.search(r'\bgh\s+issue\s+create\b', command):
+        return 'gh issue create'
+    return 'gh write'
+
+
+def main():
+    payload = json.loads(sys.stdin.read())
+
+    if payload.get('tool') != 'Bash':
+        return
+
+    command = payload.get('input', {}).get('command', '')
+    exit_code = payload.get('output', {}).get('exitCode', 1)
+
+    # Only log successful writes
+    if not any(p.search(command) for p in WRITE_PATTERNS):
+        return
+    if exit_code != 0:
+        return
+
+    # Load, prune, append, save
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        ledger = json.loads(LEDGER_PATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        ledger = {'entries': []}
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=PRUNE_AFTER_HOURS)
+    ledger['entries'] = [
+        e for e in ledger['entries']
+        if datetime.fromisoformat(e['timestamp']) > cutoff
+    ]
+
+    ledger['entries'].append({
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+        'action': extract_action(command),
+        'repo': extract_repo(command),
+        'agent': os.environ.get('CLAUDE_AGENT_ID', 'unknown'),
+    })
+
+    LEDGER_PATH.write_text(json.dumps(ledger, indent=2))
+
+
+if __name__ == '__main__':
+    main()
+```
+
+## Override Mechanism
+
+Set `GITHUB_RATE_OVERRIDE=1` in the environment to bypass the rate check for a single command. This is intentionally not a config option — it should require an explicit, visible override:
+
+```bash
+GITHUB_RATE_OVERRIDE=1 gh pr create --title "Emergency fix" --body "..."
+```
+
+The override does not suppress PostToolUse logging — the write is still recorded in the ledger.
+
+## Troubleshooting
+
+**Hook not firing**
+Verify `.claude/settings.json` is valid JSON (syntax errors silently disable all hooks). The matcher must be `"Bash"` with a capital B — it matches the Claude Code tool name, not the shell. Check with:
+```bash
+python3 -m json.tool .claude/settings.json
+```
+
+**False positives (legitimate writes blocked)**
+Add the repo's org to `OUR_ORGS` in `github-rate-check.py`, or use `GITHUB_RATE_OVERRIDE=1` for the specific command. If a whole class of repos should always be exempt, extend the `is_exempt` function with additional logic (e.g., check if the repo is a personal fork).
+
+**Ledger not persisting between sessions**
+Check that `STATE_DIR` resolves to a writable absolute path. The default `~/.local/share/kithkit/github-rate` expands correctly for the user running Claude Code. If you override `STATE_DIR` via environment, ensure it is set consistently across all sessions. Verify:
+```bash
+ls -la ~/.local/share/kithkit/github-rate/ledger.json
+```
+
+**Peer agent coordination (multiple agents sharing the ledger)**
+All agents on the same machine share the same `STATE_DIR`. The ledger is not write-locked — concurrent writes from multiple agents can race. For low-frequency writes (a few per hour) this is acceptable. If you need strict coordination, wrap the ledger read/write in a file lock using `fcntl.flock`.
+
+**PostToolUse not logging (writes happening but not counted)**
+The PostToolUse hook receives `exitCode` in `payload['output']['exitCode']`. Confirm the `gh` command is actually succeeding (exit code 0). Run the hook manually:
+```bash
+echo '{"tool":"Bash","input":{"command":"gh pr create --repo org/repo"},"output":{"exitCode":0}}' \
+  | python3 ~/.config/kithkit/hooks/github-rate-log.py
+cat ~/.local/share/kithkit/github-rate/ledger.json
+```

--- a/.claude/skills/integration/recipes/graph-email.md
+++ b/.claude/skills/integration/recipes/graph-email.md
@@ -1,0 +1,234 @@
+# Microsoft Graph Email Integration
+
+Use the Microsoft Graph API (client credentials flow) to read, search, send, and manage email in a Microsoft 365 mailbox without interactive sign-in.
+
+## Prerequisites
+
+- Microsoft 365 account with an accessible mailbox
+- Azure portal access (`portal.azure.com`)
+- Global Admin or Application Admin consent to grant app permissions
+- Kithkit daemon running
+
+## Setup
+
+### 1. Register an Azure AD application
+
+1. Go to **Azure Active Directory > App registrations > New registration**
+2. Name it (e.g., `kithkit-graph-email`)
+3. Supported account type: **Single tenant**
+4. No redirect URI required for client credentials
+5. Click **Register** and note the **Application (client) ID** and **Directory (tenant) ID**
+
+### 2. Add API permissions
+
+In **API permissions > Add a permission > Microsoft Graph > Application permissions**, add:
+
+| Permission | Purpose |
+|------------|---------|
+| `Mail.ReadWrite` | Read and move messages |
+| `Mail.Send` | Send messages |
+
+Click **Grant admin consent** — all application permissions require it.
+
+### 3. Create a client secret
+
+**Certificates & secrets > New client secret**. Set an expiry (12 or 24 months). Copy the **Value** immediately — it is not shown again.
+
+### 4. Store credentials in Keychain
+
+```bash
+security add-generic-password -s credential-graph-client-id     -a bmo -w "<CLIENT_ID>"
+security add-generic-password -s credential-graph-client-secret  -a bmo -w "<CLIENT_SECRET>"
+security add-generic-password -s credential-graph-tenant-id      -a bmo -w "<TENANT_ID>"
+security add-generic-password -s credential-graph-mailbox        -a bmo -w "you@yourdomain.com"
+```
+
+## Configuration
+
+```yaml
+extensions:
+  email:
+    enabled: true
+    provider: graph
+    graph:
+      client_id_credential:     credential-graph-client-id
+      client_secret_credential: credential-graph-client-secret
+      tenant_id_credential:     credential-graph-tenant-id
+      mailbox_credential:       credential-graph-mailbox
+      token_cache_ttl_seconds:  3500   # slightly under the 3600s token lifetime
+      max_results:              25
+```
+
+## Key Reference Code
+
+### GraphEmailProvider (TypeScript)
+
+```typescript
+// providers/graph-email-provider.ts
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+interface TokenCache {
+  token: string;
+  expiresAt: number;
+}
+
+export class GraphEmailProvider implements EmailProvider {
+  private cache: TokenCache | null = null;
+
+  constructor(private readonly cfg: GraphConfig) {}
+
+  // --- Auth ---
+
+  private async getToken(): Promise<string> {
+    const now = Date.now();
+    if (this.cache && this.cache.expiresAt > now + 60_000) {
+      return this.cache.token;
+    }
+
+    const [clientId, clientSecret, tenantId] = await Promise.all([
+      this.readCredential(this.cfg.client_id_credential),
+      this.readCredential(this.cfg.client_secret_credential),
+      this.readCredential(this.cfg.tenant_id_credential),
+    ]);
+
+    const url = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+    const body = new URLSearchParams({
+      grant_type:    'client_credentials',
+      client_id:     clientId,
+      client_secret: clientSecret,
+      scope:         'https://graph.microsoft.com/.default',
+    });
+
+    const res = await fetch(url, { method: 'POST', body });
+    if (!res.ok) throw new Error(`Token fetch failed: ${await res.text()}`);
+
+    const data = await res.json() as { access_token: string; expires_in: number };
+    this.cache = {
+      token:     data.access_token,
+      expiresAt: now + data.expires_in * 1000,
+    };
+    return this.cache.token;
+  }
+
+  private async authHeaders(): Promise<Record<string, string>> {
+    return {
+      Authorization: `Bearer ${await this.getToken()}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private async readCredential(name: string): Promise<string> {
+    const { stdout } = await execFileAsync('security', [
+      'find-generic-password', '-s', name, '-w',
+    ]);
+    return stdout.trim();
+  }
+
+  private get baseUrl(): string {
+    return `https://graph.microsoft.com/v1.0/users/${this.mailbox}`;
+  }
+
+  private mailbox = ''; // populated lazily on first call
+
+  private async ensureMailbox(): Promise<void> {
+    if (!this.mailbox) {
+      this.mailbox = await this.readCredential(this.cfg.mailbox_credential);
+    }
+  }
+
+  // --- EmailProvider interface ---
+
+  async listInbox(options?: { maxResults?: number; unreadOnly?: boolean }): Promise<Email[]> {
+    await this.ensureMailbox();
+    const max = options?.maxResults ?? this.cfg.max_results ?? 25;
+    const filter = options?.unreadOnly ? '&$filter=isRead eq false' : '';
+    const url = `${this.baseUrl}/mailFolders/Inbox/messages?$top=${max}&$orderby=receivedDateTime desc${filter}`;
+
+    const res = await fetch(url, { headers: await this.authHeaders() });
+    if (!res.ok) throw new Error(`listInbox failed: ${res.status} ${await res.text()}`);
+    const data = await res.json() as { value: GraphMessage[] };
+    return data.value.map(graphToEmail);
+  }
+
+  async readEmail(id: string): Promise<Email> {
+    await this.ensureMailbox();
+    const res = await fetch(`${this.baseUrl}/messages/${id}`, {
+      headers: await this.authHeaders(),
+    });
+    if (!res.ok) throw new Error(`readEmail failed: ${res.status}`);
+    return graphToEmail(await res.json() as GraphMessage);
+  }
+
+  async markAsRead(id: string): Promise<void> {
+    await this.ensureMailbox();
+    await fetch(`${this.baseUrl}/messages/${id}`, {
+      method:  'PATCH',
+      headers: await this.authHeaders(),
+      body:    JSON.stringify({ isRead: true }),
+    });
+  }
+
+  async moveEmail(id: string, folder: string): Promise<void> {
+    await this.ensureMailbox();
+    await fetch(`${this.baseUrl}/messages/${id}/move`, {
+      method:  'POST',
+      headers: await this.authHeaders(),
+      body:    JSON.stringify({ destinationId: folder }),
+    });
+  }
+
+  async searchEmails(query: string): Promise<Email[]> {
+    await this.ensureMailbox();
+    const encoded = encodeURIComponent(`"${query}"`);
+    const url = `${this.baseUrl}/messages?$search=${encoded}&$top=20`;
+    const res = await fetch(url, { headers: await this.authHeaders() });
+    if (!res.ok) throw new Error(`searchEmails failed: ${res.status}`);
+    const data = await res.json() as { value: GraphMessage[] };
+    return data.value.map(graphToEmail);
+  }
+
+  async sendEmail(to: string, subject: string, body: string): Promise<void> {
+    await this.ensureMailbox();
+    await fetch(`${this.baseUrl}/sendMail`, {
+      method:  'POST',
+      headers: await this.authHeaders(),
+      body: JSON.stringify({
+        message: {
+          subject,
+          toRecipients: [{ emailAddress: { address: to } }],
+          body: { contentType: 'Text', content: body },
+        },
+      }),
+    });
+  }
+}
+
+// --- Mapping helper ---
+
+function graphToEmail(m: GraphMessage): Email {
+  return {
+    id:        m.id,
+    subject:   m.subject ?? '(no subject)',
+    from:      m.from?.emailAddress?.address ?? '',
+    to:        m.toRecipients?.map(r => r.emailAddress.address) ?? [],
+    date:      m.receivedDateTime,
+    body:      m.body?.content ?? '',
+    isRead:    m.isRead,
+    folderId:  m.parentFolderId,
+  };
+}
+```
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `AADSTS700016: Application not found` | Wrong client ID or wrong tenant | Double-check the App registration's **Application ID** and **Tenant ID** |
+| `AADSTS7000215: Invalid client secret` | Secret expired or copied incorrectly | Rotate the secret in Azure portal; re-store in Keychain |
+| `403 Forbidden` on mail endpoints | Admin consent not granted | In Azure portal, click **Grant admin consent for [tenant]** |
+| `404` on mailbox URL | Mailbox UPN in Keychain doesn't match licensed M365 user | Confirm UPN with `GET /v1.0/users` |
+| Token expires mid-session | Cache TTL too long | Set `token_cache_ttl_seconds` to 3500 (5-minute buffer before 3600s expiry) |
+| `$search` returns nothing | Graph search indexes with delay | Wait ~30s after new mail arrives; use `$filter` for exact matches |

--- a/.claude/skills/integration/recipes/himalaya-email.md
+++ b/.claude/skills/integration/recipes/himalaya-email.md
@@ -1,0 +1,238 @@
+# Himalaya CLI Email Integration
+
+Use the [Himalaya](https://github.com/soywod/himalaya) command-line email client as the simplest path to IMAP access. Works with Gmail (App Password), Outlook, Fastmail, and any standard IMAP provider. No OAuth2 app registration required.
+
+## Prerequisites
+
+- Himalaya CLI installed (see setup step 1)
+- An IMAP-capable email account
+- For Gmail: [App Password](https://myaccount.google.com/apppasswords) (requires 2FA enabled)
+- Kithkit daemon running
+
+## Setup
+
+### 1. Install Himalaya
+
+**macOS (Homebrew):**
+
+```bash
+brew install himalaya
+```
+
+**Cargo:**
+
+```bash
+cargo install himalaya
+```
+
+Verify:
+
+```bash
+himalaya --version
+```
+
+### 2. Configure accounts
+
+Himalaya reads `~/.config/himalaya/config.toml`. Create it:
+
+```toml
+# ~/.config/himalaya/config.toml
+
+[accounts.gmail]
+default = true
+email   = "you@gmail.com"
+
+backend.type       = "imap"
+backend.host       = "imap.gmail.com"
+backend.port       = 993
+backend.encryption = "tls"
+backend.login      = "you@gmail.com"
+backend.auth.type  = "password"
+backend.auth.raw   = "your-app-password"   # or use keyring (see below)
+
+sender.type        = "smtp"
+sender.host        = "smtp.gmail.com"
+sender.port        = 465
+sender.encryption  = "tls"
+sender.login       = "you@gmail.com"
+sender.auth.type   = "password"
+sender.auth.raw    = "your-app-password"
+```
+
+**Using system Keychain instead of raw password (recommended):**
+
+```toml
+backend.auth.type     = "keyring"
+backend.auth.entry    = "himalaya:gmail"    # stored as generic password with service "himalaya:gmail"
+```
+
+Store the App Password:
+
+```bash
+security add-generic-password -s himalaya:gmail -a bmo -w "<APP_PASSWORD>"
+```
+
+### 3. Test the connection
+
+```bash
+himalaya envelope list --account gmail
+himalaya envelope list --account gmail --folder INBOX --max-count 5
+```
+
+### 4. Add a second account (optional)
+
+```toml
+[accounts.work]
+email = "you@yourcompany.com"
+
+backend.type       = "imap"
+backend.host       = "imap.yourcompany.com"
+backend.port       = 993
+backend.encryption = "tls"
+backend.login      = "you@yourcompany.com"
+backend.auth.type  = "password"
+backend.auth.raw   = "your-password"
+
+sender.type        = "smtp"
+sender.host        = "smtp.yourcompany.com"
+sender.port        = 587
+sender.encryption  = "starttls"
+sender.login       = "you@yourcompany.com"
+sender.auth.type   = "password"
+sender.auth.raw    = "your-password"
+```
+
+## Configuration
+
+```yaml
+extensions:
+  email:
+    enabled: true
+    provider: himalaya
+    himalaya:
+      binary: himalaya        # or absolute path if not in PATH
+      account: gmail          # matches [accounts.<name>] in himalaya config
+      max_results: 25
+      # Multi-account: specify per-operation below
+      accounts:
+        primary: gmail
+        work:    work
+```
+
+## Key Reference Code
+
+### HimalayaEmailProvider (TypeScript)
+
+```typescript
+// providers/himalaya-email-provider.ts
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export class HimalayaEmailProvider implements EmailProvider {
+  constructor(private readonly cfg: HimalayaConfig) {}
+
+  private get bin(): string { return this.cfg.binary ?? 'himalaya'; }
+  private get acct(): string { return this.cfg.account; }
+
+  /**
+   * Run himalaya and parse JSON output.
+   * Himalaya may emit WARN lines to stdout before the JSON — filter them.
+   */
+  private async run(args: string[]): Promise<unknown> {
+    const fullArgs = ['--account', this.acct, '--output', 'json', ...args];
+    const { stdout } = await execFileAsync(this.bin, fullArgs);
+
+    // Strip any leading WARN / INFO lines that himalaya writes before JSON
+    const lines = stdout.split('\n');
+    const jsonStart = lines.findIndex(l => l.trimStart().startsWith('[') || l.trimStart().startsWith('{'));
+    if (jsonStart === -1) throw new Error(`No JSON in himalaya output:\n${stdout}`);
+    const jsonText = lines.slice(jsonStart).join('\n');
+    return JSON.parse(jsonText);
+  }
+
+  async listInbox(options?: { maxResults?: number; unreadOnly?: boolean }): Promise<Email[]> {
+    const max = options?.maxResults ?? this.cfg.max_results ?? 25;
+    const args = ['envelope', 'list', '--folder', 'INBOX', '--max-count', String(max)];
+    const raw = (await this.run(args)) as HimalayaEnvelope[];
+
+    let emails = raw.map(himalayaToEmail);
+    if (options?.unreadOnly) {
+      emails = emails.filter(e => !e.isRead);
+    }
+    return emails;
+  }
+
+  async readEmail(id: string): Promise<Email> {
+    const raw = (await this.run(['message', 'read', id])) as HimalayaMessage;
+    return himalayaMessageToEmail(raw);
+  }
+
+  async moveEmail(id: string, folder: string): Promise<void> {
+    await this.run(['message', 'move', '--folder', folder, id]);
+  }
+
+  async searchEmails(query: string): Promise<Email[]> {
+    // Himalaya search wraps IMAP SEARCH — checks subject and from by default
+    const raw = (await this.run(['envelope', 'list', '--query', query])) as HimalayaEnvelope[];
+    return raw.map(himalayaToEmail);
+  }
+
+  async sendEmail(to: string, subject: string, body: string): Promise<void> {
+    // Build a minimal RFC 2822 message and pipe it to `himalaya message send`
+    const raw = [
+      `To: ${to}`,
+      `Subject: ${subject}`,
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      body,
+    ].join('\r\n');
+
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(this.bin, ['--account', this.acct, 'message', 'send'], {
+        stdio: ['pipe', 'inherit', 'inherit'],
+      });
+      child.stdin.end(raw, 'utf8');
+      child.on('close', code => code === 0 ? resolve() : reject(new Error(`himalaya send exited ${code}`)));
+    });
+  }
+}
+
+// --- Mapping helpers ---
+
+function himalayaToEmail(e: HimalayaEnvelope): Email {
+  return {
+    id:      String(e.id),
+    subject: e.subject ?? '(no subject)',
+    from:    e.from?.addr ?? '',
+    to:      [],
+    date:    e.date,
+    body:    '',          // envelope list does not include body
+    isRead:  e.flags ? !e.flags.includes('Unseen') : true,
+  };
+}
+
+function himalayaMessageToEmail(m: HimalayaMessage): Email {
+  return {
+    id:      String(m.id),
+    subject: m.subject ?? '(no subject)',
+    from:    m.from?.addr ?? '',
+    to:      (m.to ?? []).map(r => r.addr),
+    date:    m.date,
+    body:    m.text_plain ?? m.text_html ?? '',
+    isRead:  true,  // reading marks it read
+  };
+}
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `command not found: himalaya` | Not in PATH or wrong binary path | Use absolute path in config: `binary: /usr/local/bin/himalaya`; verify with `which himalaya` |
+| `JSON parse error` | WARN/INFO lines before JSON in stdout | The provider's `run()` method strips leading non-JSON lines — ensure you are using the reference implementation |
+| `authentication failed` / `Invalid credentials` | Wrong App Password or Keychain entry name | For Gmail: generate a new App Password at `myaccount.google.com/apppasswords`; for keyring mode confirm service name matches |
+| `moveEmail` silently fails | Destination folder name incorrect | List folders with `himalaya folder list --account gmail` to get exact names (e.g., `[Gmail]/All Mail`) |
+| No emails returned | Wrong account name in config | Ensure `account:` in `kithkit.config.yaml` matches the key in `~/.config/himalaya/config.toml` |
+| Gmail IMAP disabled | IMAP not enabled in Gmail settings | Go to Gmail > Settings > See all settings > Forwarding and POP/IMAP > Enable IMAP |

--- a/.claude/skills/integration/recipes/jmap-email.md
+++ b/.claude/skills/integration/recipes/jmap-email.md
@@ -1,0 +1,337 @@
+# JMAP Email Integration (Fastmail)
+
+JMAP (RFC 8620) is a modern JSON-based email protocol that replaces IMAP. A single HTTP endpoint accepts batched method calls and returns batched responses, making it far more efficient than IMAP's connection-per-session model.
+
+## Protocol Overview
+
+```
+Client                          JMAP Server
+  |                                 |
+  |  POST /jmap/api                 |
+  |  { "using": [...],              |
+  |    "methodCalls": [             |
+  |      ["Email/query", {...}, "0"],|
+  |      ["Email/get",   {...}, "1"] |
+  |    ] }                          |
+  |  -----------------------------> |
+  |                                 |
+  |  { "methodResponses": [         |
+  |      ["Email/query", {...}, "0"],|
+  |      ["Email/get",   {...}, "1"] |
+  |    ] }                          |
+  |  <----------------------------- |
+```
+
+One round-trip fetches email IDs and full message content together.
+
+---
+
+## Prerequisites
+
+- Fastmail account (or any RFC 8620-compliant JMAP server)
+- Fastmail API token with Mail read/write scope
+- Node.js 22+ with `node-fetch` available
+
+---
+
+## Setup
+
+### 1. Generate API Token
+
+In Fastmail: Settings > Privacy & Security > Connected Apps > New API token.
+Scopes needed: `urn:ietf:params:jmap:mail` (read + write).
+
+### 2. Store Token in Keychain
+
+```bash
+security add-generic-password \
+  -s credential-jmap-api-token \
+  -a bmo \
+  -w "<your-token-here>"
+```
+
+Retrieve at runtime:
+
+```bash
+security find-generic-password -s credential-jmap-api-token -w
+```
+
+### 3. Discover Session URL
+
+Fastmail's well-known URL: `https://api.fastmail.com/.well-known/jmap`
+
+```bash
+curl -s -H "Authorization: Bearer $(security find-generic-password -s credential-jmap-api-token -w)" \
+  https://api.fastmail.com/.well-known/jmap | jq '{apiUrl, primaryAccounts}'
+```
+
+The response includes `apiUrl` (where you POST all calls) and your `accountId`.
+
+---
+
+## Config Snippet
+
+```yaml
+email:
+  provider:
+    type: jmap
+    session_url: https://api.fastmail.com/.well-known/jmap
+    credential_name: credential-jmap-api-token
+    # Optional overrides
+    default_mailbox: Inbox
+    sent_mailbox: Sent
+    trash_mailbox: Trash
+```
+
+---
+
+## Reference Code
+
+### JmapEmailProvider — Core Structure
+
+```typescript
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+interface JmapSession {
+  apiUrl: string;
+  downloadUrl: string;
+  primaryAccounts: Record<string, string>;
+  capabilities: Record<string, unknown>;
+}
+
+interface JmapConfig {
+  sessionUrl: string;
+  credentialName: string;
+}
+
+export class JmapEmailProvider {
+  private session: JmapSession | null = null;
+  private sessionFetchedAt: number = 0;
+  private readonly SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+  constructor(private config: JmapConfig) {}
+
+  // Session discovery with TTL-based cache
+  private async getSession(): Promise<JmapSession> {
+    const now = Date.now();
+    if (this.session && now - this.sessionFetchedAt < this.SESSION_TTL_MS) {
+      return this.session;
+    }
+
+    const token = await this.getToken();
+    const { stdout } = await execFileAsync('curl', [
+      '-sf',
+      '-H', `Authorization: Bearer ${token}`,
+      this.config.sessionUrl,
+    ]);
+
+    this.session = JSON.parse(stdout) as JmapSession;
+    this.sessionFetchedAt = now;
+    return this.session;
+  }
+
+  private async getToken(): Promise<string> {
+    const { stdout } = await execFileAsync('security', [
+      'find-generic-password',
+      '-s', this.config.credentialName,
+      '-w',
+    ]);
+    return stdout.trim();
+  }
+
+  private getAccountId(session: JmapSession): string {
+    const id = session.primaryAccounts['urn:ietf:params:jmap:mail'];
+    if (!id) throw new Error('No JMAP mail account found in session');
+    return id;
+  }
+
+  // POST a batch of method calls
+  private async call(methodCalls: unknown[][]): Promise<unknown[][]> {
+    const session = await this.getSession();
+    const accountId = this.getAccountId(session);
+    const token = await this.getToken();
+
+    const body = JSON.stringify({
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls,
+    });
+
+    const { stdout } = await execFileAsync('curl', [
+      '-sf',
+      '-X', 'POST',
+      '-H', `Authorization: Bearer ${token}`,
+      '-H', 'Content-Type: application/json',
+      '-d', body,
+      session.apiUrl,
+    ]);
+
+    const response = JSON.parse(stdout) as { methodResponses: unknown[][] };
+    return response.methodResponses;
+  }
+```
+
+### resolveMailboxId
+
+```typescript
+  private mailboxCache = new Map<string, string>();
+
+  async resolveMailboxId(name: string): Promise<string> {
+    if (this.mailboxCache.has(name)) return this.mailboxCache.get(name)!;
+
+    const session = await this.getSession();
+    const accountId = this.getAccountId(session);
+
+    const responses = await this.call([
+      ['Mailbox/get', { accountId, ids: null }, '0'],
+    ]);
+
+    const [, result] = responses[0] as [string, { list: Array<{ id: string; name: string }> }];
+    for (const box of result.list) {
+      this.mailboxCache.set(box.name, box.id);
+    }
+
+    const id = this.mailboxCache.get(name);
+    if (!id) throw new Error(`Mailbox not found: ${name}`);
+    return id;
+  }
+```
+
+### Batched Email/query + Email/get
+
+```typescript
+  async fetchUnread(mailboxName: string = 'Inbox', limit: number = 20) {
+    const session = await this.getSession();
+    const accountId = this.getAccountId(session);
+    const mailboxId = await this.resolveMailboxId(mailboxName);
+
+    // Single round-trip: query IDs then get full messages
+    const responses = await this.call([
+      ['Email/query', {
+        accountId,
+        filter: { inMailbox: mailboxId, notKeyword: '$seen' },
+        sort: [{ property: 'receivedAt', isAscending: false }],
+        limit,
+      }, '0'],
+      ['Email/get', {
+        accountId,
+        '#ids': { resultOf: '0', name: 'Email/query', path: '/ids' },
+        properties: ['id', 'subject', 'from', 'receivedAt', 'preview', 'keywords', 'mailboxIds'],
+      }, '1'],
+    ]);
+
+    const [, getResult] = responses[1] as [string, { list: EmailMessage[] }];
+    return getResult.list;
+  }
+```
+
+### Email/set — markAsRead, moveEmail
+
+```typescript
+  async markAsRead(emailId: string): Promise<void> {
+    const session = await this.getSession();
+    const accountId = this.getAccountId(session);
+
+    await this.call([
+      ['Email/set', {
+        accountId,
+        update: {
+          [emailId]: { 'keywords/$seen': true },
+        },
+      }, '0'],
+    ]);
+  }
+
+  async moveEmail(emailId: string, destMailboxName: string): Promise<void> {
+    const session = await this.getSession();
+    const accountId = this.getAccountId(session);
+    const destId = await this.resolveMailboxId(destMailboxName);
+
+    // Get current mailboxIds first
+    const getResp = await this.call([
+      ['Email/get', { accountId, ids: [emailId], properties: ['mailboxIds'] }, '0'],
+    ]);
+    const [, getResult] = getResp[0] as [string, { list: Array<{ mailboxIds: Record<string, boolean> }> }];
+    const currentMailboxIds = getResult.list[0]?.mailboxIds ?? {};
+
+    // Replace all mailbox memberships with destination
+    const newMailboxIds = Object.fromEntries(
+      Object.keys(currentMailboxIds).map(k => [k, null])
+    );
+    newMailboxIds[destId] = true;
+
+    await this.call([
+      ['Email/set', {
+        accountId,
+        update: { [emailId]: { mailboxIds: newMailboxIds } },
+      }, '0'],
+    ]);
+  }
+```
+
+### sendEmail via Email/set create + EmailSubmission/set
+
+```typescript
+  async sendEmail(opts: {
+    to: string;
+    subject: string;
+    textBody: string;
+    fromAddress?: string;
+  }): Promise<void> {
+    const session = await this.getSession();
+    const accountId = this.getAccountId(session);
+    const draftId = await this.resolveMailboxId('Drafts');
+
+    const now = new Date().toISOString();
+    const bodyPartId = 'body-text';
+
+    await this.call([
+      // Step 1: create the Email object
+      ['Email/set', {
+        accountId,
+        create: {
+          draft1: {
+            from: [{ email: opts.fromAddress ?? 'me@fastmail.com' }],
+            to: [{ email: opts.to }],
+            subject: opts.subject,
+            keywords: { $draft: true },
+            mailboxIds: { [draftId]: true },
+            bodyStructure: { partId: bodyPartId, type: 'text/plain' },
+            bodyValues: { [bodyPartId]: { value: opts.textBody } },
+          },
+        },
+      }, '0'],
+      // Step 2: submit using created ID
+      ['EmailSubmission/set', {
+        accountId,
+        create: {
+          sub1: {
+            emailId: '#draft1',
+            envelope: {
+              mailFrom: { email: opts.fromAddress ?? 'me@fastmail.com' },
+              rcptTo: [{ email: opts.to }],
+            },
+          },
+        },
+        onSuccessDestroyEmail: ['#sub1'],
+      }, '1'],
+    ]);
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| `401 Unauthorized` on session fetch | Token missing or revoked | Re-run `security find-generic-password` to verify; regenerate token in Fastmail settings |
+| `404` or `503` on session URL | Wrong `session_url` in config | Confirm URL is `https://api.fastmail.com/.well-known/jmap` for Fastmail |
+| `Email/set` returns `notFound` error | Email ID stale or already moved | Re-query `Email/query` to get fresh IDs |
+| Mailbox ID resolution fails | Mailbox name doesn't match server name exactly | Log `Mailbox/get` response; names are case-sensitive and locale-specific |
+| Session cache returns stale `apiUrl` | Server rotated URL (rare) | Call `invalidateSession()` or reduce `SESSION_TTL_MS`; force re-fetch on `4xx` |
+| Batched call only returns first response | Server-side method limit hit | Split into smaller batches; JMAP servers may cap `methodCalls` length |
+| `EmailSubmission/set` fails silently | SMTP submission quota or identity mismatch | Check `notCreated` map in the response; verify `envelope.mailFrom` matches an identity |

--- a/.claude/skills/integration/recipes/outlook-imap.md
+++ b/.claude/skills/integration/recipes/outlook-imap.md
@@ -1,0 +1,269 @@
+# Outlook IMAP + OAuth2 Integration
+
+Access an Outlook/Microsoft 365 mailbox over IMAP using OAuth2 (SASL XOAUTH2). This approach is receive-only — use the Graph email provider for sending.
+
+> **IMPORTANT:** This requires a **separate** Azure AD app from the Graph email integration. The two apps use different permission types (delegated vs. application) and different auth flows. Do not reuse the Graph app registration.
+
+## Prerequisites
+
+- Azure portal access (`portal.azure.com`)
+- Python 3.9+ with `requests` and `msal` packages
+- Kithkit daemon running
+- For sending: set up the Graph email provider alongside this one
+
+## Setup
+
+### 1. Register a NEW Azure AD application
+
+1. **Azure Active Directory > App registrations > New registration**
+2. Name it differently from your Graph app (e.g., `kithkit-imap-delegated`)
+3. Redirect URI: set **Mobile and desktop applications** to `https://login.microsoftonline.com/common/oauth2/nativeclient`
+4. Note the **Application (client) ID**
+
+### 2. Add delegated permissions
+
+**API permissions > Add a permission > Microsoft Graph > Delegated permissions**:
+
+| Permission | Purpose |
+|------------|---------|
+| `IMAP.AccessAsUser.All` | IMAP access as the signed-in user |
+| `offline_access` | Refresh tokens |
+| `User.Read` | Verify identity |
+
+No admin consent is required for delegated permissions — the user grants them during device code flow.
+
+### 3. Enable public client
+
+**Authentication > Advanced settings > Allow public client flows: Yes**. This is required for device code flow.
+
+### 4. Run device code flow to obtain tokens
+
+```bash
+python3 -c "
+import msal, json
+
+CLIENT_ID = '<YOUR_CLIENT_ID>'
+AUTHORITY = 'https://login.microsoftonline.com/common'
+SCOPES = ['https://outlook.office.com/IMAP.AccessAsUser.All', 'offline_access']
+
+app = msal.PublicClientApplication(CLIENT_ID, authority=AUTHORITY)
+flow = app.initiate_device_flow(scopes=SCOPES)
+print(flow['message'])  # Instructs you to visit a URL and enter a code
+
+result = app.acquire_token_by_device_flow(flow)
+print(json.dumps(result, indent=2))
+"
+```
+
+Visit the URL printed, authenticate as the mailbox user, and grant consent. The script prints the token response — store the refresh token:
+
+```bash
+security add-generic-password -s credential-outlook-imap-client-id      -a bmo -w "<CLIENT_ID>"
+security add-generic-password -s credential-outlook-imap-refresh-token   -a bmo -w "<REFRESH_TOKEN>"
+```
+
+### 5. Install Python dependencies
+
+```bash
+pip3 install msal requests
+```
+
+## Configuration
+
+```yaml
+extensions:
+  email:
+    enabled: true
+    provider: outlook
+    outlook:
+      client_id_credential:      credential-outlook-imap-client-id
+      refresh_token_credential:  credential-outlook-imap-refresh-token
+      mailbox:                   you@yourdomain.com
+      imap_host:                 outlook.office365.com
+      imap_port:                 993
+      python_adapter:            extensions/email/outlook-imap.py
+      max_results:               25
+```
+
+## Key Reference Code
+
+### OutlookImapProvider (TypeScript wrapper)
+
+```typescript
+// providers/outlook-imap-provider.ts
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export class OutlookImapProvider implements EmailProvider {
+  constructor(private readonly cfg: OutlookConfig) {}
+
+  private async runAdapter(args: string[]): Promise<unknown> {
+    const clientId      = await this.readCredential(this.cfg.client_id_credential);
+    const refreshToken  = await this.readCredential(this.cfg.refresh_token_credential);
+
+    const env = {
+      ...process.env,
+      OUTLOOK_CLIENT_ID:     clientId,
+      OUTLOOK_REFRESH_TOKEN: refreshToken,
+      OUTLOOK_MAILBOX:       this.cfg.mailbox,
+      OUTLOOK_IMAP_HOST:     this.cfg.imap_host,
+    };
+
+    const { stdout } = await execFileAsync(
+      'python3',
+      [this.cfg.python_adapter, ...args],
+      { env },
+    );
+    return JSON.parse(stdout);
+  }
+
+  private async readCredential(name: string): Promise<string> {
+    const { stdout } = await execFileAsync('security', [
+      'find-generic-password', '-s', name, '-w',
+    ]);
+    return stdout.trim();
+  }
+
+  async listInbox(options?: { maxResults?: number; unreadOnly?: boolean }): Promise<Email[]> {
+    const args = ['list', '--folder', 'INBOX', '--max', String(options?.maxResults ?? 25)];
+    if (options?.unreadOnly) args.push('--unread');
+    return (await this.runAdapter(args)) as Email[];
+  }
+
+  async readEmail(id: string): Promise<Email> {
+    return (await this.runAdapter(['read', '--uid', id])) as Email;
+  }
+
+  async searchEmails(query: string): Promise<Email[]> {
+    // NOTE: default search checks SUBJECT and FROM only.
+    // For body search pass --body flag.
+    return (await this.runAdapter(['search', '--query', query])) as Email[];
+  }
+
+  async moveEmail(id: string, folder: string): Promise<void> {
+    await this.runAdapter(['move', '--uid', id, '--to', folder]);
+  }
+
+  // Sending is NOT supported — use the Graph provider for outbound mail.
+  async sendEmail(): Promise<never> {
+    throw new Error('OutlookImapProvider is receive-only. Use GraphEmailProvider to send.');
+  }
+}
+```
+
+### Python IMAP adapter with SASL XOAUTH2
+
+```python
+#!/usr/bin/env python3
+# extensions/email/outlook-imap.py
+import imaplib, base64, json, os, sys, argparse
+import msal
+
+CLIENT_ID    = os.environ['OUTLOOK_CLIENT_ID']
+REFRESH_TOKEN = os.environ['OUTLOOK_REFRESH_TOKEN']
+MAILBOX      = os.environ['OUTLOOK_MAILBOX']
+IMAP_HOST    = os.environ.get('OUTLOOK_IMAP_HOST', 'outlook.office365.com')
+AUTHORITY    = 'https://login.microsoftonline.com/common'
+SCOPES       = ['https://outlook.office.com/IMAP.AccessAsUser.All']
+
+
+def get_access_token() -> str:
+    app = msal.PublicClientApplication(CLIENT_ID, authority=AUTHORITY)
+    result = app.acquire_token_by_refresh_token(REFRESH_TOKEN, scopes=SCOPES)
+    if 'error' in result:
+        raise RuntimeError(f"Token refresh failed: {result['error_description']}")
+    return result['access_token']
+
+
+def xoauth2_string(user: str, token: str) -> str:
+    return base64.b64encode(
+        f'user={user}\x01auth=Bearer {token}\x01\x01'.encode()
+    ).decode()
+
+
+def connect() -> imaplib.IMAP4_SSL:
+    token  = get_access_token()
+    xoauth = xoauth2_string(MAILBOX, token)
+    imap   = imaplib.IMAP4_SSL(IMAP_HOST)
+    imap.authenticate('XOAUTH2', lambda _: xoauth)
+    return imap
+
+
+def cmd_list(args) -> None:
+    imap = connect()
+    imap.select(args.folder)
+    criteria = '(UNSEEN)' if args.unread else 'ALL'
+    _, data = imap.search(None, criteria)
+    uids = data[0].split()[-args.max:]
+    emails = []
+    for uid in reversed(uids):
+        _, msg_data = imap.fetch(uid, '(ENVELOPE)')
+        # parse envelope and emit minimal Email object
+        emails.append({'id': uid.decode(), 'raw': msg_data[0][1].decode(errors='replace')})
+    print(json.dumps(emails))
+    imap.logout()
+
+
+def cmd_search(args) -> None:
+    imap = connect()
+    imap.select('INBOX')
+    # Search subject and sender; use BODY for full-text (slower)
+    _, data = imap.search(None, f'(OR SUBJECT "{args.query}" FROM "{args.query}")')
+    uids = data[0].split()
+    results = []
+    for uid in uids[-20:]:
+        _, msg_data = imap.fetch(uid, '(RFC822)')
+        results.append({'id': uid.decode(), 'raw': msg_data[0][1].decode(errors='replace')})
+    print(json.dumps(results))
+    imap.logout()
+
+
+def cmd_move(args) -> None:
+    imap = connect()
+    imap.select('INBOX')
+    imap.uid('COPY', args.uid, args.to)
+    imap.uid('STORE', args.uid, '+FLAGS', r'(\Deleted)')
+    imap.expunge()
+    imap.logout()
+    print(json.dumps({'ok': True}))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest='command')
+
+    p_list = sub.add_parser('list')
+    p_list.add_argument('--folder', default='INBOX')
+    p_list.add_argument('--max', type=int, default=25)
+    p_list.add_argument('--unread', action='store_true')
+    p_list.set_defaults(func=cmd_list)
+
+    p_search = sub.add_parser('search')
+    p_search.add_argument('--query', required=True)
+    p_search.set_defaults(func=cmd_search)
+
+    p_move = sub.add_parser('move')
+    p_move.add_argument('--uid', required=True)
+    p_move.add_argument('--to', required=True)
+    p_move.set_defaults(func=cmd_move)
+
+    args = parser.parse_args()
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `AUTHENTICATE failed` | Wrong client ID — most common mistake | Verify you are using the **delegated** app's client ID, not the Graph app's ID |
+| `error: invalid_grant` on token refresh | Refresh token expired (90-day inactivity limit) | Re-run device code flow to obtain a fresh refresh token; store it in Keychain |
+| `IMAP.AccessAsUser.All` missing from consent | Permission not added or public client not enabled | Add permission in Azure portal; enable **Allow public client flows** |
+| Body search returns no results | Default search only checks SUBJECT and FROM | Pass `--body` flag to the adapter or add `BODY "term"` to IMAP search criteria |
+| Python adapter not found | Wrong path in config | Use absolute path or path relative to daemon working directory |
+| Archive folder not searched | IMAP only searches selected folder | Call list/search again with `--folder Archive` |

--- a/.claude/skills/integration/recipes/telegram.md
+++ b/.claude/skills/integration/recipes/telegram.md
@@ -1,0 +1,253 @@
+# Telegram Bot Integration
+
+Connect Kithkit's comms agent to Telegram so messages from safe senders are injected into the Claude session and replies are sent back via the bot.
+
+## Prerequisites
+
+- Kithkit daemon running (`GET /health` returns 200)
+- Telegram account
+- For webhook mode: a publicly reachable HTTPS endpoint (Cloudflare Tunnel or ngrok)
+
+## Setup
+
+### 1. Create a bot
+
+Open Telegram, start a chat with `@BotFather`, and run:
+
+```
+/newbot
+```
+
+Follow the prompts. BotFather will give you an HTTP API token.
+
+### 2. Store token in Keychain
+
+```bash
+security add-generic-password -s credential-telegram-bot -a bmo -w "<YOUR_TOKEN>"
+```
+
+The daemon reads this credential at startup.
+
+### 3. Find your chat ID
+
+Start a conversation with your bot, then call:
+
+```bash
+curl "https://api.telegram.org/bot<TOKEN>/getUpdates" | jq '.result[].message.chat.id'
+```
+
+### 4. Set up delivery — choose one mode
+
+**Webhook mode (recommended for production)**
+
+Point Telegram at your HTTPS endpoint:
+
+```bash
+curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \
+  -d "url=https://your-tunnel.example.com/telegram/webhook"
+```
+
+Verify:
+
+```bash
+curl "https://api.telegram.org/bot<TOKEN>/getWebhookInfo"
+```
+
+**Polling mode (simpler, no public URL needed)**
+
+Set `polling: true` in config (see below). The daemon polls every few seconds. Do not use alongside webhook — Telegram will reject one of them.
+
+### 5. Add your chat ID to safe-senders
+
+Edit `kithkit.config.yaml`:
+
+```yaml
+telegram:
+  safe_senders:
+    - chat_id: 123456789   # your personal Telegram user ID
+      name: Dave
+```
+
+## Configuration
+
+### Webhook mode
+
+```yaml
+extensions:
+  telegram:
+    enabled: true
+    mode: webhook
+    webhook_path: /telegram/webhook
+    token_credential: credential-telegram-bot
+    safe_senders:
+      - chat_id: 123456789
+        name: Dave
+    media_dir: data/telegram-media
+    max_message_length: 4000
+```
+
+### Polling mode
+
+```yaml
+extensions:
+  telegram:
+    enabled: true
+    mode: polling
+    poll_interval_ms: 3000
+    token_credential: credential-telegram-bot
+    safe_senders:
+      - chat_id: 123456789
+        name: Dave
+    media_dir: data/telegram-media
+    max_message_length: 4000
+```
+
+## Architecture
+
+```
+Telegram Cloud
+      |
+      | HTTPS POST (webhook) or GET (polling)
+      v
+Cloudflare Tunnel / ngrok
+      |
+      v
+Daemon  /telegram/webhook
+      |
+      | classify sender
+      | dedup update_id
+      v
+tmux inject -> comms session (Claude)
+      |
+      v
+Claude processes message
+      |
+      v
+POST /api/send  { channels: ["telegram"] }
+      |
+      v
+Daemon  sendMessage API
+      |
+      v
+Telegram Cloud -> User
+```
+
+## Key Reference Code
+
+### Webhook handler with dedup
+
+```typescript
+// extensions/telegram/webhook.ts
+const seen = new Set<number>();
+
+app.post(config.webhook_path, async (req, res) => {
+  const update = req.body as TelegramUpdate;
+  res.sendStatus(200); // ack immediately
+
+  if (!update.message) return;
+  const { update_id, message } = update;
+
+  // Dedup: Telegram may retry on timeout
+  if (seen.has(update_id)) return;
+  seen.add(update_id);
+  if (seen.size > 1000) {
+    const first = seen.values().next().value;
+    seen.delete(first);
+  }
+
+  const classification = classifySender(message.chat.id);
+  if (classification === 'blocked') return;
+  if (classification !== 'safe') {
+    await notifyPending(message);
+    return;
+  }
+
+  await injectToSession(message.text ?? '[media]');
+});
+```
+
+### sendMessage with truncation
+
+```typescript
+async function sendMessage(chatId: number, text: string): Promise<void> {
+  const MAX = 4000; // Telegram limit is 4096; leave headroom
+  const chunks: string[] = [];
+
+  for (let i = 0; i < text.length; i += MAX) {
+    chunks.push(text.slice(i, i + MAX));
+  }
+
+  for (const chunk of chunks) {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text: chunk, parse_mode: 'Markdown' }),
+    });
+  }
+}
+```
+
+### Typing indicator
+
+```typescript
+// Send "bot is typing" while Claude works.
+// Max 3 minutes to avoid runaway loops.
+
+async function withTyping(chatId: number, fn: () => Promise<void>): Promise<void> {
+  const MAX_MS = 3 * 60 * 1000;
+  const INTERVAL_MS = 4000;
+  const start = Date.now();
+
+  const timer = setInterval(async () => {
+    if (Date.now() - start > MAX_MS) { clearInterval(timer); return; }
+    await fetch(`https://api.telegram.org/bot${token}/sendChatAction`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, action: 'typing' }),
+    });
+  }, INTERVAL_MS);
+
+  try {
+    await fn();
+  } finally {
+    clearInterval(timer);
+  }
+}
+```
+
+### Sender classification
+
+```typescript
+type SenderClass = 'safe' | 'approved' | 'pending' | 'blocked';
+
+function classifySender(chatId: number): SenderClass {
+  const entry = config.safe_senders.find(s => s.chat_id === chatId);
+  if (!entry) return 'pending';
+  return entry.status ?? 'safe';
+}
+```
+
+### Media handling
+
+```typescript
+// Download and save a photo (largest available size)
+async function savePhoto(photo: TelegramPhotoSize[]): Promise<string> {
+  const largest = photo.sort((a, b) => b.file_size - a.file_size)[0];
+  const fileInfo = await getFile(largest.file_id);
+  const url = `https://api.telegram.org/file/bot${token}/${fileInfo.file_path}`;
+  const dest = path.join(config.media_dir, path.basename(fileInfo.file_path));
+  await downloadToFile(url, dest);
+  return dest;
+}
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Webhook receives nothing | Telegram can't reach your URL | Check tunnel is running; re-register webhook URL |
+| Double messages delivered | Webhook AND polling both active | Set only one mode; delete webhook with `deleteWebhook` API |
+| Agent not responding to messages | Chat ID not in safe_senders | Add the correct chat ID; check classification logs |
+| Media files not saving | `media_dir` missing or not writable | Create directory; check permissions |
+| Polling conflicts / 409 errors | Webhook still registered | Call `deleteWebhook` before enabling polling |
+| Markdown render errors | Unescaped special chars | Strip or escape `_*[]()~` in output before sending |

--- a/.claude/skills/integration/recipes/voice-client.md
+++ b/.claude/skills/integration/recipes/voice-client.md
@@ -1,0 +1,475 @@
+# Voice Client (macOS Menu Bar App)
+
+A lightweight macOS menu bar app that handles audio input/output, wake word detection, and push-to-talk. Communicates with the Kithkit daemon over HTTP — no direct Claude API calls.
+
+---
+
+## Architecture
+
+```
+Menu Bar App (rumps)
+    |
+    +── Audio Input Thread ─── sounddevice InputStream
+    |       |
+    |       +── Wake Word Engine (openWakeWord) ── passive listening
+    |       +── PTT Key Monitor ─────────────────── optional
+    |       |
+    |       v
+    |   Recording State Machine:
+    |       IDLE ──wakeword/PTT──> RECORDING ──silence/PTT-release──> SENDING
+    |                                                                      |
+    |                                               POST /api/voice/transcribe
+    |                                                                      |
+    |                                               POST /api/send (transcript)
+    |                                                                      v
+    +── Audio Output Thread ──────────────────── POST /api/tts/synthesize
+    |       |                                                              |
+    |       v                                                              |
+    |   sounddevice OutputStream (WAV playback)  <──────────── WAV bytes
+    |
+    +── Status Icon ──── IDLE / LISTENING / SPEAKING / ERROR
+    |
+    +── Daemon Heartbeat ──── GET /api/voice/client-status (every 30s)
+    +── ChimeHandler ──────── plays chime sounds on state transitions
+```
+
+---
+
+## Prerequisites
+
+- macOS 13 (Ventura) or later
+- Python 3.12+
+- Kithkit daemon running with STT and TTS extensions healthy
+- Microphone permission granted to Terminal (or the .app bundle)
+
+---
+
+## Setup
+
+### Install Python Dependencies
+
+```bash
+source ~/.kithkit/voice-venv/bin/activate
+
+pip install \
+  sounddevice \
+  numpy \
+  requests \
+  pyyaml \
+  rumps \
+  openwakeword
+
+# Verify
+python3 -c "import sounddevice, rumps, openwakeword; print('OK')"
+```
+
+### Download openWakeWord Base Model
+
+```bash
+python3 -c "
+import openwakeword
+openwakeword.utils.download_models()
+print('Models downloaded')
+"
+```
+
+### Place Client Script
+
+```bash
+mkdir -p ~/.kithkit/voice-client
+# Copy client.py to ~/.kithkit/voice-client/client.py
+# (see Reference Code below)
+```
+
+---
+
+## Client Config Reference
+
+The client reads from `kithkit.config.yaml` (via daemon's config API) or a local `client-config.yaml`. All fields under `channels.voice.client`:
+
+```yaml
+channels:
+  voice:
+    client:
+      daemon_url: http://127.0.0.1:3847
+
+      # Audio input
+      audio:
+        sample_rate: 16000       # Hz — must match STT model expectation
+        channels: 1              # Mono
+        dtype: int16             # Raw format for whisper
+        chunk_size: 512          # Frames per callback
+        silence_threshold: 0.01  # RMS below this = silence
+        silence_duration_s: 1.5  # Seconds of silence before stopping record
+
+      # Wake word
+      wake_word:
+        enabled: true
+        model: hey_mycroft        # Built-in: hey_mycroft, hey_jarvis, alexa
+                                  # Or path to custom .tflite model
+        threshold: 0.7            # Detection confidence (0.0–1.0)
+        cooldown_s: 2.0           # Minimum seconds between triggers
+
+      # Push-to-talk (mutually exclusive with wake_word in practice)
+      ptt:
+        enabled: false
+        key: F13                  # macOS key name
+
+      # Chime sounds (optional)
+      chime:
+        listen_start: ~/.kithkit/sounds/listen-start.wav
+        listen_end: ~/.kithkit/sounds/listen-end.wav
+        error: ~/.kithkit/sounds/error.wav
+
+      # Heartbeat
+      heartbeat_interval_s: 30
+      heartbeat_timeout_s: 90    # Daemon marks client stale after this
+```
+
+---
+
+## Reference Code
+
+### Client Registration + Heartbeat
+
+```python
+import requests
+import threading
+import time
+import socket
+
+DAEMON_URL = "http://127.0.0.1:3847"
+CLIENT_ID = socket.gethostname()
+
+def register_with_daemon() -> None:
+    """Register this client with the daemon on startup."""
+    resp = requests.post(f"{DAEMON_URL}/api/voice/client-register", json={
+        "client_id": CLIENT_ID,
+        "capabilities": ["microphone", "speaker", "wake_word"],
+    }, timeout=5)
+    resp.raise_for_status()
+
+def start_heartbeat(interval_s: int = 30) -> threading.Thread:
+    """Send periodic heartbeat so daemon knows client is alive."""
+    def _loop():
+        while True:
+            try:
+                requests.post(f"{DAEMON_URL}/api/voice/client-heartbeat", json={
+                    "client_id": CLIENT_ID,
+                    "state": _current_state,
+                }, timeout=5)
+            except Exception as e:
+                print(f"Heartbeat failed: {e}")
+            time.sleep(interval_s)
+
+    t = threading.Thread(target=_loop, daemon=True)
+    t.start()
+    return t
+
+_current_state = "idle"
+```
+
+### record_until_silence
+
+```python
+import numpy as np
+import sounddevice as sd
+from collections import deque
+
+SAMPLE_RATE = 16000
+CHANNELS = 1
+SILENCE_THRESHOLD = 0.01
+SILENCE_DURATION_S = 1.5
+CHUNK_SIZE = 512  # frames per callback
+
+def record_until_silence() -> bytes:
+    """
+    Record audio until SILENCE_DURATION_S of silence is detected.
+    Returns raw int16 PCM bytes (16kHz mono).
+    """
+    frames: list[np.ndarray] = []
+    silence_chunks = 0
+    chunks_per_second = SAMPLE_RATE / CHUNK_SIZE
+    silence_chunk_limit = int(SILENCE_DURATION_S * chunks_per_second)
+    stop_event = threading.Event()
+
+    def callback(indata: np.ndarray, frame_count: int, time_info, status):
+        nonlocal silence_chunks
+        if status:
+            print(f"Audio status: {status}")
+
+        chunk = indata.copy()
+        frames.append(chunk)
+
+        # RMS energy for silence detection
+        rms = float(np.sqrt(np.mean(chunk.astype(np.float32) ** 2))) / 32768.0
+        if rms < SILENCE_THRESHOLD:
+            silence_chunks += 1
+            if silence_chunks >= silence_chunk_limit:
+                stop_event.set()
+        else:
+            silence_chunks = 0  # reset on any sound
+
+    with sd.InputStream(
+        samplerate=SAMPLE_RATE,
+        channels=CHANNELS,
+        dtype='int16',
+        blocksize=CHUNK_SIZE,
+        callback=callback,
+    ):
+        stop_event.wait(timeout=30)  # max 30s recording
+
+    audio = np.concatenate(frames, axis=0)
+    return audio.tobytes()
+```
+
+### send_to_daemon
+
+```python
+import io
+import wave
+
+def pcm_to_wav(pcm: bytes, sample_rate: int = 16000, channels: int = 1) -> bytes:
+    """Wrap raw int16 PCM in a WAV container."""
+    buf = io.BytesIO()
+    with wave.open(buf, 'wb') as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(2)  # int16 = 2 bytes
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+def send_to_daemon(pcm: bytes) -> str:
+    """Send audio to STT endpoint, return transcript."""
+    wav_bytes = pcm_to_wav(pcm)
+    resp = requests.post(
+        f"{DAEMON_URL}/api/voice/transcribe",
+        data=wav_bytes,
+        headers={"Content-Type": "audio/wav"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()["transcript"]
+```
+
+### play_audio
+
+```python
+def play_audio(wav_bytes: bytes) -> None:
+    """Play WAV audio through the default output device."""
+    buf = io.BytesIO(wav_bytes)
+    with wave.open(buf, 'rb') as wf:
+        sample_rate = wf.getframerate()
+        channels = wf.getnchannels()
+        frames = wf.readframes(wf.getnframes())
+
+    audio = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+    if channels > 1:
+        audio = audio.reshape(-1, channels)
+
+    sd.play(audio, samplerate=sample_rate, blocking=True)
+```
+
+### voice_pipeline — Main State Machine
+
+```python
+def voice_pipeline(chime: 'ChimeHandler') -> None:
+    """Full turn: record -> transcribe -> send -> TTS -> play."""
+    global _current_state
+
+    chime.play('listen_start')
+    _current_state = 'listening'
+
+    try:
+        pcm = record_until_silence()
+        chime.play('listen_end')
+        _current_state = 'processing'
+
+        transcript = send_to_daemon(pcm)
+        if not transcript.strip():
+            _current_state = 'idle'
+            return
+
+        # Send transcript to comms via daemon
+        requests.post(f"{DAEMON_URL}/api/send", json={
+            "message": transcript,
+            "channels": ["voice"],
+            "source": "voice_client",
+        }, timeout=10)
+
+        # Wait for TTS response
+        _current_state = 'speaking'
+        resp = requests.post(
+            f"{DAEMON_URL}/api/tts/synthesize",
+            json={"text": "<pending>"},  # daemon fills from comms response
+            timeout=60,
+        )
+        if resp.ok and resp.headers.get('Content-Type', '').startswith('audio/'):
+            play_audio(resp.content)
+
+    except Exception as e:
+        chime.play('error')
+        print(f"Voice pipeline error: {e}")
+    finally:
+        _current_state = 'idle'
+```
+
+### ChimeHandler — Daemon-Initiated Notifications
+
+```python
+import os
+
+class ChimeHandler:
+    """Plays chime sounds and handles daemon-pushed audio notifications."""
+
+    def __init__(self, cfg: dict):
+        self.sounds = {
+            'listen_start': cfg.get('listen_start', ''),
+            'listen_end': cfg.get('listen_end', ''),
+            'error': cfg.get('error', ''),
+        }
+
+    def play(self, name: str) -> None:
+        path = self.sounds.get(name, '')
+        if path and os.path.exists(path):
+            try:
+                with wave.open(path, 'rb') as wf:
+                    frames = wf.readframes(wf.getnframes())
+                    rate = wf.getframerate()
+                audio = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+                sd.play(audio, samplerate=rate, blocking=False)
+            except Exception as e:
+                print(f"Chime error ({name}): {e}")
+
+    def poll_daemon_notifications(self) -> None:
+        """
+        Poll daemon for outbound voice notifications (e.g. timer alarms,
+        comms-initiated alerts). Daemon queues these at /api/voice/notifications.
+        """
+        try:
+            resp = requests.get(
+                f"{DAEMON_URL}/api/voice/notifications",
+                params={"client_id": CLIENT_ID},
+                timeout=5,
+            )
+            if not resp.ok:
+                return
+            for note in resp.json().get("notifications", []):
+                if note.get("type") == "audio" and note.get("wav_b64"):
+                    import base64
+                    wav_bytes = base64.b64decode(note["wav_b64"])
+                    play_audio(wav_bytes)
+                    requests.delete(
+                        f"{DAEMON_URL}/api/voice/notifications/{note['id']}",
+                        timeout=5,
+                    )
+        except Exception:
+            pass
+```
+
+---
+
+## Wake Word Training with openWakeWord
+
+Use this when the built-in wake words are not suitable. Training runs in Google Colab (free tier is sufficient).
+
+```
+1. Record 10–30 positive samples of your wake phrase (WAV, 16kHz mono, ~1s each)
+2. Upload to Colab: https://colab.research.google.com/drive/...openWakeWord-training
+3. Set TARGET_PHRASE in Colab config
+4. Run all cells — generates a .tflite model file
+5. Download the .tflite, place at ~/.kithkit/models/wake/<phrase>.tflite
+6. Update config:
+     wake_word:
+       model: /Users/bmo/.kithkit/models/wake/hey_bmo.tflite
+       threshold: 0.6   # start lower for custom models
+```
+
+openWakeWord docs: https://github.com/dscripka/openWakeWord
+
+---
+
+## macOS .app Wrapper
+
+Wrap the client in a proper .app bundle so it can be added to Login Items and appears as a named app in the Dock/Activity Monitor.
+
+### Info.plist
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>Kithkit Voice</string>
+  <key>CFBundleExecutable</key>
+  <string>launcher</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.kithkit.voice-client</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>KithkitVoice</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleVersion</key>
+  <string>1.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <!-- LSUIElement=true → no Dock icon, menu bar only -->
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Kithkit Voice requires microphone access for voice input.</string>
+</dict>
+</plist>
+```
+
+### Launcher Script
+
+```bash
+#!/usr/bin/env bash
+# KithkitVoice.app/Contents/MacOS/launcher
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV_PYTHON="/Users/bmo/.kithkit/voice-venv/bin/python3"
+CLIENT_SCRIPT="/Users/bmo/.kithkit/voice-client/client.py"
+
+exec "$VENV_PYTHON" "$CLIENT_SCRIPT" >> /tmp/kithkit-voice.log 2>&1
+```
+
+### Build and Sign
+
+```bash
+APP_PATH="$HOME/Applications/KithkitVoice.app"
+mkdir -p "$APP_PATH/Contents/MacOS"
+mkdir -p "$APP_PATH/Contents/Resources"
+
+# Copy files
+cp Info.plist "$APP_PATH/Contents/"
+cp launcher "$APP_PATH/Contents/MacOS/"
+chmod +x "$APP_PATH/Contents/MacOS/launcher"
+
+# Ad-hoc codesign (no Apple Developer account needed for personal use)
+codesign --force --deep --sign - "$APP_PATH"
+
+# Add to Login Items via osascript
+osascript -e "
+  tell application \"System Events\"
+    make new login item at end of login items \
+      with properties {path:\"$APP_PATH\", hidden:true}
+  end tell
+"
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| No menu bar icon after launch | `rumps` requires a GUI session; SSH sessions won't show menu bar | Launch from a terminal opened in a GUI session (not SSH). For .app, launch from Finder or Login Items. |
+| Microphone permission denied | macOS requires explicit mic permission per app | Open System Settings > Privacy & Security > Microphone. Grant access to Terminal or the .app bundle. |
+| Daemon not receiving audio | `daemon_url` wrong, or `Content-Type: audio/wav` missing | Test: `curl -s -X POST http://127.0.0.1:3847/api/voice/transcribe -H "Content-Type: audio/wav" --data-binary @test.wav`. Check client logs at `/tmp/kithkit-voice.log`. |
+| Wake word fires constantly or never | Threshold mistuned | Start at 0.5 for custom models, 0.7 for built-ins. Increase to reduce false positives; decrease if it never triggers. Check ambient noise RMS vs `silence_threshold`. |
+| PTT key not detected | macOS accessibility permission not granted | System Settings > Privacy & Security > Accessibility — add Terminal or the .app. Without this, global key monitoring is blocked. |
+| Audio playback rate mismatch (chipmunk/slow voice) | `play_audio` uses TTS `sample_rate` but wav header says different | Always read `wf.getframerate()` from the WAV header rather than hardcoding a rate. Kokoro outputs 24kHz; confirm client passes that to `sd.play`. |
+| Client heartbeat stale / daemon shows client offline | Client crashed silently, or heartbeat interval too long | Check `/tmp/kithkit-voice.log`. Reduce `heartbeat_interval_s`. Add a crash-restart wrapper in the launcher script (`while true; do python3 client.py; sleep 2; done`). |

--- a/.claude/skills/integration/recipes/voice-integration.md
+++ b/.claude/skills/integration/recipes/voice-integration.md
@@ -1,0 +1,262 @@
+# Voice Integration Overview
+
+Voice integration adds a fully on-device voice pipeline to Kithkit. All three components run locally — no cloud STT or TTS services required.
+
+---
+
+## Architecture
+
+```
+User speaks
+    |
+    v
+[ Voice Client ]  ──────────────────────────────────────────────────────────
+  macOS menu bar app                                                         |
+  - Wake word detection (openWakeWord) or PTT key                           |
+  - Audio capture (sounddevice)                                              |
+  - Silence detection                                                        |
+    |                                                                        |
+    | POST /api/voice/transcribe (raw audio bytes)                          |
+    v                                                                        |
+[ STT — whisper-cpp ]  ─────────────────────────────────────────────────   |
+  Daemon extension                                                           |
+  - Runs whisper.cpp via subprocess                                          |
+  - Returns transcript text                                                  |
+    |                                                                       |
+    | transcript text                                                       |
+    v                                                                       |
+  Daemon routes to comms agent → Claude responds                            |
+    |                                                                       |
+    | response text                                                         |
+    v                                                                       |
+[ TTS — Kokoro-ONNX ]  ─────────────────────────────────────────────────  |
+  Daemon extension                                                           |
+  - Runs Python + Kokoro ONNX model                                         |
+  - Returns WAV audio bytes                                                  |
+    |                                                                       |
+    | WAV audio (chunked)                                                   |
+    v                                                                       |
+[ Voice Client ]  ──────────────────────────────────────────────────────  |
+  - Plays audio via sounddevice                                              |
+  - Status icon updates (idle / listening / speaking)                        |
+```
+
+All three components are independent services. They communicate only through the daemon's HTTP API.
+
+---
+
+## Component Recipe Order
+
+Install and validate in this order — each layer depends on the one before it:
+
+1. **TTS (Kokoro-ONNX)** — `recipes/tts-kokoro.md`
+   - Requires: Python 3.12+ venv, `kokoro-onnx` package, ONNX model files
+   - Validates independently: `GET /api/tts/health`
+
+2. **STT (whisper-cpp)** — `recipes/stt-whisper.md`
+   - Requires: compiled `whisper-cpp` binary, `.gguf` model file
+   - Validates independently: `POST /api/voice/transcribe` with a test WAV
+
+3. **Voice Client** — `recipes/voice-client.md`
+   - Requires: daemon running with both STT and TTS healthy, Python deps
+   - Validates: full round-trip speak → transcript → response → audio playback
+
+Do not attempt to set up the Voice Client before both STT and TTS are confirmed healthy.
+
+---
+
+## Quick Start Checklist
+
+```bash
+# 1. Set up Python venv (shared by TTS and Voice Client)
+python3.12 -m venv ~/.kithkit/voice-venv
+source ~/.kithkit/voice-venv/bin/activate
+pip install kokoro-onnx sounddevice numpy requests pyyaml rumps openwakeword
+
+# 2. Download Kokoro ONNX model files
+mkdir -p ~/.kithkit/models/kokoro
+curl -L -o ~/.kithkit/models/kokoro/kokoro-v1.0.onnx \
+  https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files/kokoro-v1.0.onnx
+curl -L -o ~/.kithkit/models/kokoro/voices.bin \
+  https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files/voices.bin
+
+# 3. Build whisper.cpp
+git clone https://github.com/ggerganov/whisper.cpp ~/.kithkit/whisper.cpp
+cd ~/.kithkit/whisper.cpp && make -j$(sysctl -n hw.ncpu)
+
+# 4. Download whisper model (base.en recommended for speed)
+bash ~/.kithkit/whisper.cpp/models/download-ggml-model.sh base.en
+
+# 5. Add voice config to kithkit.config.yaml (see Config Reference below)
+
+# 6. Reload daemon config
+curl -s -X POST http://localhost:3847/api/config/reload
+
+# 7. Verify all components (see Verification Commands below)
+
+# 8. Launch Voice Client
+source ~/.kithkit/voice-venv/bin/activate
+python3 ~/.kithkit/voice-client/client.py
+```
+
+---
+
+## Verification Commands
+
+### TTS Health Check
+
+```bash
+curl -s http://localhost:3847/api/tts/health | jq .
+# Expected: { "status": "ok", "model": "kokoro-v1.0", "voices": [...] }
+```
+
+### Voice (STT) Status
+
+```bash
+curl -s http://localhost:3847/api/voice/status | jq .
+# Expected: { "status": "ready", "model": "base.en", "binary": "/path/to/main" }
+```
+
+### TTS Round-Trip
+
+```bash
+curl -s -X POST http://localhost:3847/api/tts/synthesize \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello, voice integration is working.", "voice": "af_sky"}' \
+  -o /tmp/tts-test.wav
+
+# Play it
+afplay /tmp/tts-test.wav
+```
+
+### STT Round-Trip
+
+```bash
+# Record 3 seconds of audio (requires SoX)
+rec -r 16000 -c 1 -b 16 /tmp/stt-test.wav trim 0 3
+
+# Transcribe
+curl -s -X POST http://localhost:3847/api/voice/transcribe \
+  -H "Content-Type: audio/wav" \
+  --data-binary @/tmp/stt-test.wav | jq .
+# Expected: { "transcript": "...", "duration_ms": ... }
+```
+
+---
+
+## Required Validation in Extension onInit
+
+The voice extension must validate all dependencies before registering its routes. A missing component should disable the extension cleanly, not crash the daemon.
+
+```typescript
+import { existsSync, accessSync, constants } from 'fs';
+import { execFileSync } from 'child_process';
+
+export async function onInit(daemon: DaemonContext) {
+  const cfg = daemon.config.channels?.voice;
+  if (!cfg?.enabled) {
+    daemon.logger.info('voice', 'Voice extension disabled in config');
+    return;
+  }
+
+  const errors: string[] = [];
+
+  // 1. Python venv
+  const venvPython = cfg.python_venv;
+  if (!existsSync(venvPython)) {
+    errors.push(`Python venv not found: ${venvPython}`);
+  }
+
+  // 2. Kokoro ONNX model files
+  const kokoroModel = cfg.tts.model_path;
+  const kokoroVoices = cfg.tts.voices_path;
+  if (!existsSync(kokoroModel)) errors.push(`Kokoro model not found: ${kokoroModel}`);
+  if (!existsSync(kokoroVoices)) errors.push(`Kokoro voices not found: ${kokoroVoices}`);
+
+  // 3. whisper-cpp binary
+  const whisperBin = cfg.stt.binary_path;
+  if (!existsSync(whisperBin)) {
+    errors.push(`whisper.cpp binary not found: ${whisperBin}`);
+  } else {
+    try {
+      accessSync(whisperBin, constants.X_OK);
+    } catch {
+      errors.push(`whisper.cpp binary not executable: ${whisperBin}`);
+    }
+  }
+
+  // 4. whisper model file
+  const whisperModel = cfg.stt.model_path;
+  if (!existsSync(whisperModel)) errors.push(`Whisper model not found: ${whisperModel}`);
+
+  if (errors.length > 0) {
+    daemon.logger.error('voice', 'Voice extension disabled due to missing dependencies:');
+    for (const e of errors) daemon.logger.error('voice', `  - ${e}`);
+    // Do NOT throw — let daemon continue without voice
+    return;
+  }
+
+  // All checks passed — register routes
+  registerVoiceRoutes(daemon);
+  registerTtsRoutes(daemon);
+  daemon.logger.info('voice', 'Voice extension initialized successfully');
+}
+```
+
+---
+
+## Config Reference
+
+```yaml
+channels:
+  voice:
+    enabled: true
+    python_venv: /Users/bmo/.kithkit/voice-venv/bin/python3
+
+    tts:
+      enabled: true
+      model_path: /Users/bmo/.kithkit/models/kokoro/kokoro-v1.0.onnx
+      voices_path: /Users/bmo/.kithkit/models/kokoro/voices.bin
+      default_voice: af_sky
+      sample_rate: 24000
+      speed: 1.0
+
+    stt:
+      enabled: true
+      binary_path: /Users/bmo/.kithkit/whisper.cpp/main
+      model_path: /Users/bmo/.kithkit/whisper.cpp/models/ggml-base.en.bin
+      language: en
+      threads: 4
+
+    client:
+      # These are read by the Voice Client, not the daemon
+      daemon_url: http://127.0.0.1:3847
+      wake_word:
+        enabled: true
+        model: hey_mycroft   # or path to custom .tflite
+        threshold: 0.7
+      ptt:
+        enabled: false
+        key: F13              # function key for PTT
+      audio:
+        sample_rate: 16000
+        channels: 1
+        silence_threshold: 0.01
+        silence_duration_s: 1.5
+      chime:
+        listen_start: /Users/bmo/.kithkit/sounds/listen-start.wav
+        listen_end: /Users/bmo/.kithkit/sounds/listen-end.wav
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Daemon crashes on startup after adding voice config | Missing Python venv or model files; exception propagating from `onInit` | Ensure `onInit` uses the guard pattern above (log errors, return early, do not throw). Check daemon logs for the specific missing path. |
+| TTS health returns `error` | Kokoro model load failed (wrong path, corrupt download) | Re-download model files; verify SHA if provided. Run `python3 -c "import kokoro_onnx"` in the venv to check the package itself. |
+| STT transcription fails | whisper.cpp binary missing execute permission or wrong model format | Run `chmod +x` on the binary. Confirm model is `.gguf` format (not `.bin` from older repos). |
+| Voice Client can't connect to daemon | Wrong `daemon_url` or daemon not running | `curl http://127.0.0.1:3847/health` from the same machine. Check client config `daemon_url`. |
+| TTS works, STT doesn't (or vice versa) | Components are independent — one can fail without affecting the other | Check each extension's health endpoint separately. Restart just the affected component's process. |
+| Everything works in test, silent in production | System audio output device changed | Check macOS Sound settings. Voice Client uses the default output device — switch to the correct one. |

--- a/.claude/skills/integration/recipes/voice-stt.md
+++ b/.claude/skills/integration/recipes/voice-stt.md
@@ -1,0 +1,130 @@
+# Speech-to-Text (Whisper CLI)
+
+On-device speech recognition via whisper-cpp. No API keys required — everything runs locally.
+
+## Prerequisites
+
+- macOS with Homebrew
+- whisper-cpp (`brew install whisper-cpp`)
+
+## Setup
+
+```bash
+# Install whisper-cpp
+brew install whisper-cpp
+
+# Download a model (small.en recommended for most use cases)
+whisper-cpp-download-ggml-model small.en
+
+# Test with a WAV file (must be 16kHz mono 16-bit PCM)
+whisper-cli -m ~/.cache/whisper/ggml-small.en.bin -f test.wav
+```
+
+### Model Size Comparison
+
+| Model       | Size   | Notes                        |
+|-------------|--------|------------------------------|
+| tiny.en     | 75MB   | Fastest, lowest accuracy     |
+| base.en     | 142MB  | Good balance for fast hardware |
+| small.en    | 466MB  | Recommended — best accuracy/speed tradeoff |
+| medium.en   | 1.5GB  | High accuracy, slower        |
+
+## Config Snippet
+
+```yaml
+channels:
+  voice:
+    stt:
+      engine: whisper-cpp
+      model: small.en
+      model_dir: ~/.cache/whisper
+      language: en
+      beam_size: 1          # REQUIRED on Apple Silicon — see Troubleshooting
+      timeout_ms: 10000
+```
+
+## Key Reference Code
+
+### Transcribe Function
+
+```typescript
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+// Known whisper hallucinations — filter these out
+const HALLUCINATIONS = new Set(['you', 'thank you', 'bye bye', 'thanks for watching']);
+
+async function transcribe(wavPath: string, modelPath: string): Promise<string | null> {
+  const { stdout } = await execFileAsync('whisper-cli', [
+    '-m', modelPath,
+    '-f', wavPath,
+    '--no-timestamps',
+    '--beam-size', '1',   // REQUIRED on Apple Silicon to avoid garbled output
+    '-l', 'en',
+    '--output-txt',
+    '--print-special', 'false',
+  ]);
+
+  const text = stdout.trim().toLowerCase();
+
+  if (!text || HALLUCINATIONS.has(text)) {
+    return null;
+  }
+
+  return stdout.trim();
+}
+```
+
+### POST /voice/stt Endpoint
+
+```typescript
+// Daemon route — accepts audio upload, returns transcript
+app.post('/voice/stt', upload.single('audio'), async (req, res) => {
+  const wavPath = req.file?.path;
+  if (!wavPath) return res.status(400).json({ error: 'No audio file provided' });
+
+  try {
+    const transcript = await transcribe(wavPath, config.stt.modelPath);
+    if (transcript === null) {
+      return res.json({ transcript: null, filtered: true });
+    }
+    return res.json({ transcript });
+  } finally {
+    fs.unlink(wavPath, () => {});  // clean up temp file
+  }
+});
+```
+
+## Troubleshooting
+
+**`whisper-cli: command not found`**
+Homebrew installs to `/opt/homebrew/bin` on Apple Silicon. Make sure it is on `PATH`. Add to shell profile:
+```bash
+export PATH="/opt/homebrew/bin:$PATH"
+```
+The daemon spawns processes with a stripped `PATH` — set `env.PATH` explicitly in the spawn options or use the absolute binary path.
+
+**Garbled / nonsense output**
+whisper-cpp requires audio to be **16kHz mono 16-bit PCM WAV**. Convert with ffmpeg:
+```bash
+ffmpeg -i input.mp3 -ar 16000 -ac 1 -sample_fmt s16 output.wav
+```
+
+**Hallucinations (empty room returns "thank you", "you", etc.)**
+This is a known whisper behaviour on silence or background noise. The `HALLUCINATIONS` filter above covers the most common false positives. Expand the set as you encounter new ones. You can also raise the VAD (voice activity detection) threshold to avoid sending silence to the model.
+
+**Very slow on Apple Silicon**
+Set `--beam-size 1` in your CLI args (already included in the reference code). Without this, whisper-cpp may use a large beam search that runs extremely slowly on Apple Silicon MPS and produces garbled results.
+
+**Timeout**
+The default `timeout_ms: 10000` is tight for larger models. For `medium.en`, increase to `30000`. Transcription time scales with audio length and model size.
+
+**Model not found**
+Models are downloaded to `~/.cache/whisper/` by `whisper-cpp-download-ggml-model`. Confirm the path:
+```bash
+ls ~/.cache/whisper/
+# Should list: ggml-small.en.bin (or whichever model you downloaded)
+```
+Set `model_dir` in config to match the actual path if it differs.

--- a/.claude/skills/integration/recipes/voice-tts.md
+++ b/.claude/skills/integration/recipes/voice-tts.md
@@ -1,0 +1,246 @@
+# Text-to-Speech (Kokoro ONNX)
+
+On-device TTS via the Kokoro ONNX model, served by a persistent Python microservice. No API costs. The daemon manages the worker lifecycle and auto-restarts it on crash.
+
+## Prerequisites
+
+- Python 3.12+
+- ~340MB disk space for model files
+- `kokoro-onnx` Python package
+
+## Setup
+
+```bash
+# Create a dedicated venv
+python3.12 -m venv ~/.venvs/kokoro
+source ~/.venvs/kokoro/bin/activate
+
+# Install kokoro-onnx
+pip install kokoro-onnx
+
+# Download model files (~340MB total)
+# kokoro-v1.0.onnx (310MB) + voices-v1.0.bin (27MB)
+python - <<'EOF'
+from huggingface_hub import hf_hub_download
+hf_hub_download(repo_id="hexgrad/Kokoro-82M-ONNX", filename="kokoro-v1.0.onnx", local_dir="~/.models/kokoro")
+hf_hub_download(repo_id="hexgrad/Kokoro-82M-ONNX", filename="voices-v1.0.bin", local_dir="~/.models/kokoro")
+EOF
+
+# Test synthesis (should produce audio.wav in current directory)
+python -c "
+from kokoro_onnx import Kokoro
+import soundfile as sf
+k = Kokoro('~/.models/kokoro/kokoro-v1.0.onnx', '~/.models/kokoro/voices-v1.0.bin')
+samples, sr = k.create('Hello from Kithkit.', voice='am_michael', speed=1.0, lang='en-us')
+sf.write('audio.wav', samples, sr)
+print('OK')
+"
+```
+
+## Config Snippet
+
+```yaml
+channels:
+  voice:
+    tts:
+      engine: kokoro
+      venv_path: ~/.venvs/kokoro
+      model_path: ~/.models/kokoro/kokoro-v1.0.onnx
+      voices_path: ~/.models/kokoro/voices-v1.0.bin
+      default_voice: am_michael
+      default_speed: 1.0
+      worker:
+        port: 3848
+        startup_timeout_ms: 90000   # model loading can take 30-60s on first run
+        health_check_interval_ms: 30000
+        max_restart_attempts: 3
+```
+
+## Available Voices
+
+| Voice ID    | Gender | Accent  | Character      |
+|-------------|--------|---------|----------------|
+| am_adam     | M      | American | Neutral        |
+| am_michael  | M      | American | Clear, warm    |
+| af_bella    | F      | American | Bright         |
+| af_sarah    | F      | American | Calm           |
+| bf_emma     | F      | British  | Crisp          |
+| bm_george   | M      | British  | Authoritative  |
+| bm_lewis    | M      | British  | Casual         |
+
+Run `Kokoro.list_voices()` on your installed version for the full list, as it expands with model updates.
+
+## Key Reference Code
+
+### tts-worker.py (Python Microservice)
+
+```python
+#!/usr/bin/env python3
+"""
+Kokoro TTS microservice. Runs on port 3848.
+Daemon starts this process and waits for "READY" on stdout before routing requests.
+"""
+import sys
+import json
+import struct
+import wave
+import io
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from kokoro_onnx import Kokoro
+
+MODEL_PATH = sys.argv[1]
+VOICES_PATH = sys.argv[2]
+PORT = int(sys.argv[3]) if len(sys.argv) > 3 else 3848
+
+kokoro = Kokoro(MODEL_PATH, VOICES_PATH)
+
+
+def samples_to_wav(samples, sample_rate: int = 24000) -> bytes:
+    """Convert float32 numpy samples to 16-bit PCM WAV bytes."""
+    pcm = (samples * 32767).astype('int16')
+    buf = io.BytesIO()
+    with wave.open(buf, 'wb') as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)          # 16-bit
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm.tobytes())
+    return buf.getvalue()
+
+
+class TTSHandler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass  # suppress access log noise
+
+    def do_POST(self):
+        if self.path != '/synthesize':
+            self.send_error(404)
+            return
+
+        length = int(self.headers.get('Content-Length', 0))
+        body = json.loads(self.rfile.read(length))
+
+        text  = body.get('text', '')
+        voice = body.get('voice', 'am_michael')
+        speed = float(body.get('speed', 1.0))
+
+        samples, sr = kokoro.create(text, voice=voice, speed=speed, lang='en-us')
+        wav_bytes = samples_to_wav(samples, sr)
+
+        self.send_response(200)
+        self.send_header('Content-Type', 'audio/wav')
+        self.send_header('Content-Length', str(len(wav_bytes)))
+        self.end_headers()
+        self.wfile.write(wav_bytes)
+
+
+server = HTTPServer(('127.0.0.1', PORT), TTSHandler)
+print('READY', flush=True)   # daemon scans stdout for this exact string
+server.serve_forever()
+```
+
+### Daemon-Side Lifecycle (TypeScript)
+
+```typescript
+import { spawn, ChildProcess } from 'child_process';
+
+interface TTSWorkerState {
+  process: ChildProcess | null;
+  ready: boolean;
+  restarts: number;
+}
+
+const MAX_RESTARTS = 3;
+const worker: TTSWorkerState = { process: null, ready: false, restarts: 0 };
+
+async function startTTSWorker(cfg: TTSConfig): Promise<void> {
+  const python = `${cfg.venvPath}/bin/python3`;
+
+  worker.process = spawn(python, [
+    cfg.workerScript,
+    cfg.modelPath,
+    cfg.voicesPath,
+    String(cfg.port),
+  ]);
+
+  await waitForReady(worker.process, cfg.startupTimeoutMs);
+  worker.ready = true;
+  worker.restarts = 0;
+
+  worker.process.on('exit', (code) => {
+    worker.ready = false;
+    if (worker.restarts < MAX_RESTARTS) {
+      worker.restarts++;
+      setTimeout(() => startTTSWorker(cfg), 2000);
+    } else {
+      console.error(`TTS worker crashed ${MAX_RESTARTS} times — giving up`);
+    }
+  });
+}
+
+async function waitForReady(proc: ChildProcess, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('TTS worker startup timeout')), timeoutMs);
+    let buffer = '';
+
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString();
+      // Split by newlines — READY may arrive mid-buffer
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (line.trim() === 'READY') {
+          clearTimeout(timer);
+          resolve();
+        }
+      }
+    });
+
+    proc.on('exit', (code) => {
+      clearTimeout(timer);
+      reject(new Error(`TTS worker exited early with code ${code}`));
+    });
+  });
+}
+```
+
+## Performance (Apple M4)
+
+| Input length | Synthesis time |
+|-------------|---------------|
+| Short (~10 words)  | ~0.4s |
+| Medium (~40 words) | ~0.9s |
+| Long (~120 words)  | ~2.4s |
+
+Performance scales roughly linearly with token count. The model runs on CPU via ONNX Runtime — no GPU/MPS dependency.
+
+## Alternative Engine
+
+**Qwen3-TTS via mlx-audio** — runs on Apple Silicon MLX, different voice characteristics. Slower than Kokoro on equivalent hardware but produces more expressive speech. Drop-in substitute if you configure `engine: qwen3-mlx` and point to the mlx-audio worker script. Not covered in detail here.
+
+## Troubleshooting
+
+**Worker won't start**
+Verify the venv path. The daemon uses the absolute path to `python3` inside the venv — it does not activate the venv. Check:
+```bash
+~/.venvs/kokoro/bin/python3 -c "import kokoro_onnx; print('ok')"
+```
+If this fails, the package is not installed in the venv.
+
+**Startup timeout (model loading takes 30-60s on first run)**
+The ONNX runtime compiles the model graph on first load and caches it. Subsequent starts are faster. Set `startup_timeout_ms: 90000` in config. If it still times out, check available RAM — the model needs ~600MB free.
+
+**Silent / empty audio output**
+The worker outputs WAV at **24kHz**. If your audio pipeline resamples to 16kHz without knowing the source rate, the result will be pitched or silent. Pass the sample rate from the HTTP response context — `samples_to_wav` uses `24000` by default, matching Kokoro's output.
+
+**`READY` signal missed / worker marked not-ready despite running**
+The `waitForReady` scanner must split by `\n`, not look for exact-length chunks. The reference code above does this correctly. A common mistake is checking `chunk.toString() === 'READY\n'` — this fails when stdout arrives in partial chunks.
+
+**Max restarts exceeded**
+The worker exited 3 times in a row. Check stderr for Python tracebacks:
+```bash
+# Temporarily redirect worker stderr to a file to capture crash output
+```
+Common causes: model file missing/corrupted, out of memory, port 3848 already in use.
+
+**`ModuleNotFoundError: No module named 'kokoro_onnx'`**
+The daemon is calling the system Python instead of the venv Python. Always use the absolute path to the venv binary (`~/.venvs/kokoro/bin/python3`), not `python3` or `python`.

--- a/.claude/skills/integration/reference.md
+++ b/.claude/skills/integration/reference.md
@@ -1,0 +1,311 @@
+# Kithkit Integration Reference
+
+## Daemon API — Full Request/Response Details
+
+All endpoints on `localhost:3847`. JSON responses include `timestamp` (ISO 8601). Invalid JSON bodies return `400 { "error": "Invalid JSON" }`.
+
+### Health & Status
+
+**GET /health** — Daemon health and extension status.
+
+```json
+{
+  "status": "ok",
+  "uptime": 3742,
+  "version": "0.1.0",
+  "degraded": false,
+  "extension": "my-agent",
+  "extensionRoutes": ["/my-ext/status", "/my-ext/*"],
+  "timestamp": "..."
+}
+```
+
+**GET /health/extended** — Run all health checks. Accepts `Accept: text/plain`.
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "daemon": { "ok": true, "message": "Daemon running", "details": { "uptime": 3742, "pid": 12345, "memoryMB": 48 } },
+    "database": { "ok": true, "message": "Database OK (12 tables)" }
+  }
+}
+```
+
+**GET /status** — Quick status: `{ "daemon": "running", "agent": "AgentName", "uptime": 3742.5 }`
+
+**GET /status/extended** — Aggregated operational status including DB stats, scheduler results, and health checks.
+
+### Agents
+
+**POST /api/agents/spawn** — Spawn a worker.
+
+```json
+{
+  "profile": "research",
+  "prompt": "Do this task",
+  "cwd": "/path/to/dir",
+  "timeoutMs": 60000,
+  "maxBudgetUsd": 0.50
+}
+```
+
+Response 202: `{ "jobId": "...", "status": "spawning" }`
+
+**GET /api/agents** — List all agents.
+
+**GET /api/agents/:id** — Get agent details (404 if not found).
+
+**GET /api/agents/:id/status** — Detailed status with token usage and cost.
+
+```json
+{ "id": "...", "status": "completed", "tokens_in": 4200, "tokens_out": 890, "cost_usd": 0.0031 }
+```
+
+**DELETE /api/agents/:id** — Kill a running worker.
+
+### Todos
+
+**GET /api/todos** — List all todos (ordered by `created_at DESC`). Tags stored as JSON string.
+
+**POST /api/todos** — Create a todo.
+
+```json
+{
+  "title": "Review PR",
+  "description": "PR #42",
+  "priority": "high",
+  "status": "pending",
+  "due_date": "2026-03-01",
+  "tags": ["review", "urgent"]
+}
+```
+
+Priority: `low | medium | high | critical`. Status: `pending | in_progress | completed | cancelled`.
+
+**GET /api/todos/:id** — Get a single todo.
+
+**GET /api/todos/:id/actions** — Audit trail (status/priority changes).
+
+**PUT /api/todos/:id** — Update (all fields optional, changes logged).
+
+**DELETE /api/todos/:id** — Hard delete (204 No Content).
+
+### Calendar
+
+**GET /api/calendar** — List events. Filter: `?date=2026-02-22`.
+
+**POST /api/calendar** — Create event.
+
+```json
+{
+  "title": "Project review",
+  "start_time": "2026-02-25T14:00:00Z",
+  "description": "Q1 review",
+  "end_time": "2026-02-25T15:00:00Z",
+  "all_day": false,
+  "source": "manual",
+  "todo_ref": 7
+}
+```
+
+**GET/PUT/DELETE /api/calendar/:id** — CRUD operations.
+
+### Messages
+
+**POST /api/messages** — Inter-agent message.
+
+```json
+{
+  "from": "comms-001",
+  "to": "worker-007",
+  "body": "Task complete",
+  "type": "text",
+  "metadata": { "priority": 1 }
+}
+```
+
+**GET /api/messages?agent=X&type=Y&limit=20** — Message history (agent required).
+
+### Channel Delivery
+
+**POST /api/send** — Deliver through channel router.
+
+```json
+{
+  "message": "Task complete",
+  "channels": ["telegram"],
+  "metadata": {}
+}
+```
+
+Omit `channels` to send to all active. Router reads channel config and forwards to matching adapters.
+
+### Memory
+
+**POST /api/memory/store** — Store a memory.
+
+```json
+{
+  "content": "User prefers concise responses",
+  "type": "fact",
+  "category": "preferences",
+  "tags": ["user", "style"],
+  "source": "conversation"
+}
+```
+
+Types: `fact | episodic | procedural`.
+
+**POST /api/memory/search** — Search memories. Three modes:
+
+Keyword (default): multi-word AND matching, tags OR matching.
+```json
+{ "mode": "keyword", "query": "concise responses", "tags": ["user"], "category": "preferences" }
+```
+
+Vector: semantic similarity via embeddings.
+```json
+{ "mode": "vector", "query": "how the user likes to communicate", "limit": 10 }
+```
+
+Hybrid: combines keyword and vector results.
+```json
+{ "mode": "hybrid", "query": "response style", "limit": 10 }
+```
+
+**GET /api/memory/:id** — Get a single memory.
+
+**DELETE /api/memory/:id** — Hard delete (204).
+
+### Config & State
+
+**GET /api/config/:key** — Get config entry (value auto-parsed from JSON).
+
+**PUT /api/config/:key** — Upsert config: `{ "value": "anything JSON-serializable" }`.
+
+**GET /api/feature-state/:feature** — Get feature state.
+
+**PUT /api/feature-state/:feature** — Upsert: `{ "state": { "enabled": true } }`.
+
+**GET /api/context** — Structured context summary for session startup. Budget: `?budget=4000` (default 8000 chars).
+
+**POST /api/config/reload** — Hot-reload `kithkit.config.yaml`. Scheduler adjusts without restart.
+
+### Scheduler / Tasks
+
+**GET /api/tasks** — List all tasks with status, schedule, next/last run times.
+
+**POST /api/tasks/:name/run** — Manual trigger (bypasses schedule and idle checks).
+
+Result: `{ "task_name": "...", "status": "success", "output": "...", "duration_ms": 48 }`.
+
+**GET /api/tasks/:name/history** — Execution history for a task.
+
+### Usage & Metrics
+
+**GET /api/usage** — Aggregate stats: `{ "tokens_in": 12345, "tokens_out": 6789, "cost_usd": 0.0412, "jobs": 7 }`.
+
+## Error Responses
+
+All errors follow: `{ "error": "message", "detail": "optional", "timestamp": "..." }`.
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Bad request — missing fields or invalid values |
+| 403 | Forbidden — access control violation |
+| 404 | Not found |
+| 500 | Internal server error |
+| 503 | Service unavailable — subsystem not initialized |
+
+## Extension Interface
+
+```typescript
+export interface Extension {
+  name: string;
+  onInit?(config: KithkitConfig, server: http.Server): Promise<void>;
+  onRoute?(req: http.IncomingMessage, res: http.ServerResponse, pathname: string, searchParams: URLSearchParams): Promise<boolean>;
+  onShutdown?(): Promise<void>;
+}
+```
+
+## TaskHandler Interface
+
+```typescript
+type TaskHandler = (context: { taskName: string; config: Record<string, unknown> }) => Promise<void>;
+```
+
+## EmailProvider Interface
+
+Shared by all email integrations (Graph, Himalaya, JMAP, Outlook IMAP):
+
+```typescript
+interface EmailMessage {
+  id: string;
+  subject: string;
+  from: string;
+  to: string[];
+  date: string;
+  body: string;
+  bodyHtml?: string;
+  isRead: boolean;
+  folder?: string;
+}
+
+interface SendOptions {
+  cc?: string[];
+  bcc?: string[];
+  replyToId?: string;
+  isHtml?: boolean;
+}
+
+interface EmailProvider {
+  name: string;
+  isConfigured(): boolean;
+  listInbox(limit?: number, unreadOnly?: boolean): Promise<EmailMessage[]>;
+  readEmail(id: string): Promise<EmailMessage | null>;
+  markAsRead(id: string): Promise<void>;
+  moveEmail?(id: string, folder: string): Promise<void>;
+  searchEmails(query: string, limit?: number): Promise<EmailMessage[]>;
+  sendEmail(to: string, subject: string, body: string, options?: SendOptions): Promise<void>;
+}
+```
+
+## Database Schema
+
+| Table | Purpose |
+|-------|---------|
+| `todos` / `todo_actions` | Todos with audit trail |
+| `memories` | Facts, decisions, episodic (with optional vector embeddings) |
+| `calendar` | Events, reminders, deadlines |
+| `messages` | Inter-agent message log |
+| `agents` / `worker_jobs` | Agent registry and job tracking |
+| `config` / `feature_state` | Runtime config and per-feature state |
+| `task_results` | Scheduler execution history |
+
+## Config Structure
+
+```yaml
+agent:
+  name: MyAgent
+  identity_file: identity.md
+
+daemon:
+  port: 3847
+  log_level: info
+  log_dir: logs
+
+scheduler:
+  tasks:
+    - name: my-task
+      interval: "1h"
+      enabled: true
+      config:
+        requires_session: false
+        idle_only: false
+
+security:
+  rate_limits:
+    incoming_max_per_minute: 5
+    outgoing_max_per_minute: 10
+```


### PR DESCRIPTION
## Summary

- Adds the `integration` skill directly to `.claude/skills/integration/` so it ships with the core framework
- Resolves the **bootstrapping chicken-and-egg problem**: agents can't install skills from the catalog without a working comms channel (Telegram/email), but can't set up those channels without the integration recipes
- Making the skill available from day one means a fresh Kithkit install can immediately set up its comms channel using the bundled recipes

## What's included

- **SKILL.md** — main skill file with YAML frontmatter matching the core skill convention (`name`, `description`, `user-invocable: false`)
- **reference.md** — full daemon API request/response reference
- **recipes/** — 12 integration guides:
  - Telegram bot (webhook/polling, sender classification, media)
  - Microsoft Graph Email (Azure AD, client credentials OAuth)
  - Outlook IMAP (device code flow, Python adapter)
  - Himalaya CLI Email (Gmail/IMAP, multi-account)
  - JMAP Email/Fastmail (RFC 8620, batched method calls)
  - Email triage scheduler task (pattern matching, sub-agent classification)
  - Voice overview, client, STT (Whisper-cpp), and TTS (Kokoro-ONNX)
  - Browserbase (cloud browser automation, sidecar)
  - GitHub rate limiting (Claude Code hooks, write ledger)

## What's excluded

Catalog-only metadata (`manifest.yaml`, `CHANGELOG.md`) was not copied — those are catalog artifacts, not needed in core.

## Test plan

- [ ] Verify `.claude/skills/integration/SKILL.md` has valid YAML frontmatter
- [ ] Confirm no `manifest.yaml` or `CHANGELOG.md` present in the skill directory
- [ ] Spot-check a recipe file to confirm content integrity
- [ ] Verify the skill appears alongside other core skills in `.claude/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)