### PR TITLE
Fix critical bugs: tmux session matching, orchestrator detection, watchdog nesting, identity config

### DIFF
--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -74,19 +74,39 @@ const GRACE_PERIOD_MS = 60 * 1000; // 60 seconds to exit after nudge
 
 /**
  * Check if the Claude process is actively running in the orchestrator's tmux session.
- * Uses `tmux list-panes -t <session> -F '#{pane_current_command}'` to see the foreground process.
- * If the pane is running 'claude' (or a child of it), the orchestrator is still working.
+ *
+ * The orchestrator runs inside a bash wrapper script, so tmux's pane_current_command
+ * always reports "bash" — not "claude". Instead, we get the wrapper's PID via
+ * `#{pane_pid}` and use `pgrep -P <panePid> -f claude` to check whether a claude
+ * process is a descendant of the wrapper. This matches the approach used by
+ * `getOrchestratorState()` in agents/tmux.ts.
  */
 function isClaudeProcessRunning(): boolean {
   try {
     const session = _getOrchestratorSession();
-    const output = execFileSync(TMUX_BIN, [
+
+    // Get the PID of the wrapper bash process that owns the tmux pane
+    const panePid = execFileSync(TMUX_BIN, [
       '-S', TMUX_SOCKET,
-      'list-panes', '-t', session, '-F', '#{pane_current_command}',
+      'display-message',
+      '-t', `${session}:`,
+      '-p', '#{pane_pid}',
     ], { encoding: 'utf8', timeout: 5000 }).trim();
-    // The pane's foreground command should be 'claude' (or 'node' running claude)
-    // If it's 'zsh' or 'bash' with no child, Claude has exited
-    return output.includes('claude') || output.includes('node');
+
+    if (!panePid || !/^\d+$/.test(panePid)) {
+      return false;
+    }
+
+    // Check if any "claude" process is a descendant of the wrapper PID.
+    // pgrep exits 0 if found, non-zero if not.
+    try {
+      execFileSync('/usr/bin/pgrep', ['-P', panePid, '-f', 'claude'], {
+        timeout: 5000,
+      });
+      return true;
+    } catch {
+      return false;
+    }
   } catch {
     return false;
   }

--- a/scripts/attach.sh
+++ b/scripts/attach.sh
@@ -15,7 +15,7 @@ if [ -z "$TMUX_BIN" ]; then
 fi
 
 if session_exists; then
-    exec $TMUX_CMD attach-session -t "$SESSION_NAME"
+    exec $TMUX_CMD attach-session -t "=$SESSION_NAME"
 else
     echo "No active session '$SESSION_NAME'. Start with: ./scripts/start-tmux.sh"
     exit 1

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -104,7 +104,7 @@ LOG_DIR="$BASE_DIR/logs"
 
 # Check if the Kithkit tmux session exists
 session_exists() {
-    [ -n "$TMUX_BIN" ] && $TMUX_CMD has-session -t "$SESSION_NAME" 2>/dev/null
+    [ -n "$TMUX_BIN" ] && $TMUX_CMD has-session -t "=$SESSION_NAME" 2>/dev/null
 }
 
 # Check if claude is actually running inside the tmux session pane
@@ -116,7 +116,7 @@ claude_alive() {
         return 1
     fi
     local pane_pid
-    pane_pid=$($TMUX_CMD list-panes -t "$SESSION_NAME" -F '#{pane_pid}' 2>/dev/null | head -1)
+    pane_pid=$($TMUX_CMD list-panes -t "=$SESSION_NAME" -F '#{pane_pid}' 2>/dev/null | head -1)
     if [ -z "$pane_pid" ]; then
         return 1
     fi

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -25,7 +25,7 @@ rm -f "$RESTART_FLAG"
 # Kill existing session if running
 if session_exists; then
     kithkit_log "Killing existing session '$SESSION_NAME'..."
-    $TMUX_CMD kill-session -t "$SESSION_NAME"
+    $TMUX_CMD kill-session -t "=$SESSION_NAME"
     sleep 2
 fi
 

--- a/scripts/start-tmux.sh
+++ b/scripts/start-tmux.sh
@@ -46,7 +46,7 @@ if session_exists; then
     else
         # Session exists but claude is dead — kill stale session and recreate
         echo "Session '$SESSION_NAME' exists but claude is not running — restarting"
-        $TMUX_CMD kill-session -t "$SESSION_NAME" 2>/dev/null
+        $TMUX_CMD kill-session -t "=$SESSION_NAME" 2>/dev/null
     fi
 fi
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -23,15 +23,19 @@ fi
 # Change to project directory
 cd "$BASE_DIR"
 
-# System prompt file location
-SYSTEM_PROMPT_FILE=".claude/state/system-prompt.txt"
+# Identity file: config > legacy fallback
+IDENTITY_FILE="$(read_config '.agent.identity_file' '')"
+if [ -z "$IDENTITY_FILE" ]; then
+    # Legacy fallback for older installations
+    IDENTITY_FILE=".claude/state/system-prompt.txt"
+fi
 
 # Build arguments array
 ARGS=()
 
-# Add system prompt if it exists
-if [ -f "$SYSTEM_PROMPT_FILE" ]; then
-    ARGS+=("--append-system-prompt" "$(cat "$SYSTEM_PROMPT_FILE")")
+# Add system prompt if identity file exists
+if [ -f "$IDENTITY_FILE" ]; then
+    ARGS+=("--append-system-prompt" "$(cat "$IDENTITY_FILE")")
 fi
 
 # Add any additional arguments passed to this script

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -13,6 +13,12 @@
 # Usage:
 #   ./watchdog.sh [start.sh arguments...]
 
+# Clear Claude Code nesting guard — the tmux session is a separate instance,
+# not a nested one. Without this, launching from an existing Claude session
+# (e.g., restart triggered by comms) fails with "cannot launch inside another
+# Claude Code session".
+unset CLAUDECODE
+
 # Source shared config
 source "$(dirname "${BASH_SOURCE[0]}")/lib/config.sh"
 


### PR DESCRIPTION
## Summary

Fixes 4 critical bugs discovered during production deployment and cross-instance audit:

### 1. Orchestrator idle detection — pgrep fix (`orchestrator-idle.ts`)
The idle checker used `tmux list-panes -F '#{pane_current_command}'` to detect whether Claude was running. This always reports `bash` because the orchestrator runs inside a bash wrapper. Replaced with `#{pane_pid}` + `pgrep -P <pid> -f claude`, matching the approach already used in `agents/tmux.ts`.

### 2. Tmux `=` prefix for exact session matching (4 shell scripts)
`tmux has-session -t "name"` does prefix matching — a session named `comms1-old` would match a check for `comms1`. Adding the `=` prefix (`-t "=$SESSION_NAME"`) forces exact matching across all session operations: `has-session`, `attach-session`, `kill-session`, and `list-panes`.

**Files:** `attach.sh`, `lib/config.sh`, `restart.sh`, `start-tmux.sh`

### 3. Watchdog CLAUDECODE nesting guard (`watchdog.sh`)
When the watchdog is triggered from within an existing Claude Code session (e.g., comms agent triggering a restart), the `CLAUDECODE` environment variable causes the new session to fail with "cannot launch inside another Claude Code session". Fixed by unsetting `CLAUDECODE` at the top of the watchdog script.

### 4. Identity file from config (`start.sh`)
`start.sh` had a hardcoded path to `.claude/state/system-prompt.txt` for the system prompt. Replaced with `read_config '.agent.identity_file'` to honor the `agent.identity_file` config setting, with the legacy path as a fallback.

## Test plan
- [ ] Verify orchestrator idle detection correctly identifies running/exited Claude processes
- [ ] Verify `session_exists` and `claude_alive` match exact session names (not prefixes)
- [ ] Verify watchdog can restart agent from within an existing Claude session
- [ ] Verify `start.sh` reads identity file path from config YAML
- [ ] Verify legacy fallback still works when `identity_file` is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)