### PR TITLE
Fix: migration runner skips missed migrations when later ones applied

### DIFF
--- a/daemon/src/core/migrations.ts
+++ b/daemon/src/core/migrations.ts
@@ -99,9 +99,11 @@ export function runMigrations(db: Database.Database, migrationsDir?: string): nu
   const dir = migrationsDir ?? getMigrationsDir();
   ensureMigrationsTable(db);
 
-  const currentVersion = getCurrentVersion(db);
+  const applied = new Set(
+    (db.prepare('SELECT version FROM migrations').all() as { version: number }[]).map(r => r.version),
+  );
   const available = discoverMigrations(dir);
-  const pending = available.filter(m => m.version > currentVersion);
+  const pending = available.filter(m => !applied.has(m.version));
 
   if (pending.length === 0) return 0;
 


### PR DESCRIPTION
## Problem

The migration runner used `MAX(version)` to determine which migrations are pending. Any migration with a version number lower than the current max was permanently skipped if it wasn't applied at the right time.

**Example:** On a fresh Skippy install, migration 005 (`last_accessed` column on memories) got skipped because later migrations (010, 011) had already run. The memories table was missing `last_accessed`, causing every memory search call to fail with `SqliteError: no such column: last_accessed`.

## Fix

Changed `runMigrations()` to track the **full set of applied migration versions** (via a Set) and filter by membership (`!applied.has(m.version)`), replacing the previous `m.version > currentVersion` filter.

This ensures any missed migration is caught and applied on next daemon start, regardless of what other migrations have run.

## Changes

- `daemon/src/core/migrations.ts` — use applied version Set instead of MAX(version) for pending filter

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)