### PR TITLE
Fix: scheduler skips gracefully when task has no handler or command

### DIFF
--- a/daemon/src/automation/scheduler.ts
+++ b/daemon/src/automation/scheduler.ts
@@ -10,6 +10,7 @@ import { CronExpressionParser } from 'cron-parser';
 import { parseInterval, type TaskScheduleConfig } from '../core/config.js';
 import { runTask, type TaskResult } from './task-runner.js';
 import { registerCoreTasks } from './tasks/index.js';
+import { createLogger } from '../core/logger.js';
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -310,14 +311,32 @@ export class Scheduler {
 
       // Use in-process handler if registered, otherwise spawn subprocess
       const handler = this._handlers.get(task.name);
-      const result = handler
-        ? await this._runInProcess(task, handler)
-        : await runTask(task.name, {
-            command: task.command,
-            args: task.args,
-            timeoutMs: (task.config.timeout_ms as number) ?? 300_000,
-            cwd: task.config.cwd as string | undefined,
-          });
+      let result: TaskResult;
+      if (handler) {
+        result = await this._runInProcess(task, handler);
+      } else if (task.command) {
+        result = await runTask(task.name, {
+          command: task.command,
+          args: task.args,
+          timeoutMs: (task.config.timeout_ms as number) ?? 300_000,
+          cwd: task.config.cwd as string | undefined,
+        });
+      } else {
+        // No handler registered and no command configured — skip gracefully.
+        // This happens when an extension task is in the scheduler config but
+        // the extension hasn't loaded yet (e.g. peer-heartbeat before agent-comms loads).
+        const log = createLogger('scheduler');
+        log.debug(`Task "${task.name}" has no handler or command — skipping`);
+        result = {
+          id: 0,
+          task_name: task.name,
+          status: 'success',
+          output: 'Skipped: no handler registered and no command configured',
+          duration_ms: 0,
+          started_at: new Date().toISOString(),
+          finished_at: new Date().toISOString(),
+        };
+      }
 
       task.lastRunAt = new Date();
       task.nextRunAt = this._calculateNextRun(task);


### PR DESCRIPTION
## Problem

When an extension task (e.g. `peer-heartbeat`) is listed in the scheduler config but the extension hasn't registered its in-process handler yet, the scheduler fell through to `runTask()`. Since the task has no `command` or `args` configured (it's handler-only), `runTask()` errored with:

```
Task "peer-heartbeat" has no args array. Shell fallback (/bin/sh -c) is disabled for security.
```

This spammed the log on every heartbeat tick and broke peer online/offline detection.

## Fix

Added a third branch in `_runTask()`: if no handler is registered **and** no command is configured, log a debug message and return a success result (skipped). This prevents log spam and errors on fresh starts before extensions fully load.

Pre-storage errors and tasks with commands still behave as before. Only the "no handler + no command" case is affected.

## Changes

- `daemon/src/automation/scheduler.ts` — skip gracefully when no handler or command

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)