### PR TITLE
Fix LAN agent-comms: IP-first host resolution, .lan→.local fallback

### DIFF
--- a/daemon/src/extensions/comms/agent-comms.ts
+++ b/daemon/src/extensions/comms/agent-comms.ts
@@ -259,8 +259,15 @@ function sendViaLAN(
   agentName: string,
 ): Promise<AgentMessageResponse> {
   const payload = JSON.stringify(msg);
-  const hosts: string[] = [peer.host];
+
+  // Build ordered host list: try direct IP first (most reliable), then mDNS .local,
+  // then configured hostname last. On macOS home networks, .lan hostnames fail DNS
+  // (NXDOMAIN), causing 5s timeouts before falling back to the IP.
+  const hosts: string[] = [];
   if (peer.ip && peer.ip !== peer.host) hosts.push(peer.ip);
+  if (peer.host.endsWith('.lan')) hosts.push(peer.host.replace(/\.lan$/, '.local'));
+  if (!hosts.includes(peer.host)) hosts.push(peer.host);
+
   const startTime = Date.now();
 
   return new Promise<AgentMessageResponse>((resolve) => {
@@ -269,7 +276,7 @@ function sendViaLAN(
       const url = `http://${host}:${peer.port}/agent/message`;
 
       const args = [
-        '-s', '--connect-timeout', '5',
+        '-s', '--connect-timeout', '3',
         '-w', '\n%{http_code}',
         '-X', 'POST', url,
         '-H', 'Content-Type: application/json',


### PR DESCRIPTION
## Summary
- Try direct IP address first when sending LAN messages (most reliable on home networks)
- Add `.lan` → `.local` mDNS fallback before trying configured hostname
- Reduce connect-timeout from 5s to 3s (more fallbacks available = faster per-attempt)

## Problem
On macOS home networks, `.lan` hostnames fail DNS resolution (NXDOMAIN). The previous code tried `peer.host` first, causing a 5s timeout before falling back to `peer.ip`. This made agent-comms slow and unreliable when peers are configured with `.lan` hostnames.

## Supersedes
Closes branches `fix/lan-agent-comms-connectivity-v2` (Skippy) — that branch put the fix in a private extension file. This applies it to core kithkit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)