### PR TITLE
Fix POST /api/config/reload — wire ConfigWatcher in main.ts

### DIFF
--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -19,7 +19,7 @@ import { recoverFromRestart } from './agents/recovery.js';
 import { handleMessagesRoute } from './api/messages.js';
 import { handleSendRoute } from './api/send.js';
 import { handleTasksRoute } from './api/tasks.js';
-import { handleConfigRoute } from './api/config.js';
+import { handleConfigRoute, setConfigWatcher } from './api/config.js';
 import { handleOrchestratorRoute } from './api/orchestrator.js';
 import { handleTimerRoute, initTimers } from './api/timer.js';
 import { handleSelftestRoute } from './api/selftest.js';
@@ -51,6 +51,7 @@ import {
   type CheckResult,
   type HealthCheckFn,
 } from './core/extended-status.js';
+import { createConfigWatcher } from './core/config-watcher.js';
 
 export const VERSION = '0.1.0';
 
@@ -101,6 +102,13 @@ openDatabase(projectDir);
 
 // Reload persisted timers (must run after openDatabase)
 initTimers();
+
+// Wire up config hot-reload watcher
+const configPath = path.resolve(projectDir, 'kithkit.config.yaml');
+const configWatcher = createConfigWatcher(configPath);
+setConfigWatcher(configWatcher);
+configWatcher.start();
+log.info('Config watcher started', { path: configPath });
 
 // Wire up agent profiles directory
 setProfilesDir(path.resolve(projectDir, '.claude', 'agents'));
@@ -344,6 +352,7 @@ async function shutdown(signal: string): Promise<void> {
     }
   }
 
+  configWatcher.stop();
   closeDatabase();
   log.info('Database closed');
 


### PR DESCRIPTION
## Summary
Wire the `ConfigWatcher` into daemon startup so `POST /api/config/reload` actually works.

## Problem
`createConfigWatcher()` in `daemon/src/core/config-watcher.ts` was never called from `main.ts`. The API handler checked for `_watcher` and returned 503 every time.

## Fix
In `main.ts`, after `initTimers()`:
1. Create a ConfigWatcher pointing at `kithkit.config.yaml`
2. Call `setConfigWatcher(watcher)` to register it with the API handler
3. Start the watcher
4. Stop it in the graceful shutdown handler

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)