### PR TITLE
Fix #25: graceful handling of relay forwarding failures

### DIFF
--- a/daemon/src/agents/message-router.ts
+++ b/daemon/src/agents/message-router.ts
@@ -76,8 +76,12 @@ function defaultTmuxInjector(agentId: string, text: string): boolean {
 
 /**
  * Send a message between agents. Logs to DB and routes to target.
+ *
+ * Always returns a result if the message was stored locally.
+ * Relay/forwarding failures are non-fatal: the message is stored and a
+ * `warning` field is included in the result instead of throwing.
  */
-export function sendMessage(req: SendMessageRequest): { messageId: number; delivered: boolean } {
+export function sendMessage(req: SendMessageRequest): { messageId: number; delivered: boolean; warning?: string } {
   // Validate type
   if (!VALID_MESSAGE_TYPES.includes(req.type)) {
     throw new MessageValidationError(`Invalid message type: ${req.type}`);
@@ -133,33 +137,44 @@ export function sendMessage(req: SendMessageRequest): { messageId: number; deliv
     }
   }
 
-  // Route to target
-  if (isPersistentAgent(req.to)) {
-    // Direct channel: bypass scheduler and inject immediately.
-    // Use body as-is — callers that set direct=true (agent-comms, sdk-bridge)
-    // have already formatted the display text (e.g. "[Agent] R2d2: message").
-    // Applying formatForTmux on top would double-wrap the prefix.
-    if (req.direct) {
-      const injected = tmuxInjector(req.to, req.body);
-      if (injected) {
-        // Mark as processed — deliver-once, no re-notification
-        exec(
-          'UPDATE messages SET processed_at = ? WHERE id = ?',
-          new Date().toISOString(), message.id,
-        );
-        return { messageId: message.id, delivered: true };
+  // Route to target — non-fatal: message is already stored locally.
+  // Relay/P2P forwarding errors are caught and returned as a warning.
+  try {
+    if (isPersistentAgent(req.to)) {
+      // Direct channel: bypass scheduler and inject immediately.
+      // Use body as-is — callers that set direct=true (agent-comms, sdk-bridge)
+      // have already formatted the display text (e.g. "[Agent] R2d2: message").
+      // Applying formatForTmux on top would double-wrap the prefix.
+      if (req.direct) {
+        const injected = tmuxInjector(req.to, req.body);
+        if (injected) {
+          // Mark as processed — deliver-once, no re-notification
+          exec(
+            'UPDATE messages SET processed_at = ? WHERE id = ?',
+            new Date().toISOString(), message.id,
+          );
+          return { messageId: message.id, delivered: true };
+        }
+        // Injection failed (session not alive) — fall through to normal delivery
       }
-      // Injection failed (session not alive) — fall through to normal delivery
+
+      // Queue for delivery — the message-delivery scheduler task handles tmux injection.
+      // Trigger the task immediately so delivery doesn't wait for the next interval tick.
+      notifyNewMessage();
+      return { messageId: message.id, delivered: false };
     }
-
-    // Queue for delivery — the message-delivery scheduler task handles tmux injection.
-    // Trigger the task immediately so delivery doesn't wait for the next interval tick.
-    notifyNewMessage();
-    return { messageId: message.id, delivered: false };
+    // Workers pull their own messages — no active delivery needed
+    return { messageId: message.id, delivered: true };
+  } catch (err) {
+    // Forwarding/routing failed after local storage — non-fatal.
+    // Log and return success with a warning so callers don't receive a 500.
+    const warning = err instanceof Error ? err.message : String(err);
+    log.warn('Message relay/forwarding failed (message stored locally)', {
+      messageId: message.id,
+      error: warning,
+    });
+    return { messageId: message.id, delivered: false, warning };
   }
-  // Workers pull their own messages — no active delivery needed
-
-  return { messageId: message.id, delivered: true };
 }
 
 /**

--- a/daemon/src/api/messages.ts
+++ b/daemon/src/api/messages.ts
@@ -76,6 +76,7 @@ export async function handleMessagesRoute(
         json(res, 200, withTimestamp({
           messageId: result.messageId,
           delivered: result.delivered,
+          ...(result.warning !== undefined ? { warning: result.warning } : {}),
         }));
       } catch (err) {
         if (err instanceof WorkerRestrictionError) {


### PR DESCRIPTION
## Summary
- Wraps post-storage routing/delivery in try/catch in `sendMessage()` so relay/P2P forwarding errors don't crash the endpoint
- Returns `{messageId, delivered: false, warning}` with 200 OK instead of 500 when forwarding fails
- Surfaces the optional `warning` field in the POST /api/messages response

## Details
When `POST /api/messages` stores a message locally and then attempts to forward it via A2A relay or P2P, a network failure (target daemon down, timeout, etc.) would throw an unhandled error and return 500 — even though the message was already persisted in SQLite. This fix catches those post-storage errors and returns a successful response with a warning, since the message *is* stored and can be delivered later.

Closes #25

## Test plan
- [ ] Send a message to an agent whose relay/P2P target is unreachable — should return 200 with `delivered: false` and `warning` field
- [ ] Send a message to a local persistent agent — should work as before (200, delivered true/false, no warning)
- [ ] Send a message to a worker — should work as before (200, delivered true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)