### PR TITLE
Fix POST /api/messages 500 on routing failure

### DIFF
--- a/daemon/src/__tests__/message-router.test.ts
+++ b/daemon/src/__tests__/message-router.test.ts
@@ -550,6 +550,48 @@ describe('Direct channel — immediate delivery for persistent agents', () => {
     assert.equal(result.delivered, true);
   });
 
+  it('direct=true returns delivered:false (not 500) when tmux injector throws', () => {
+    _setTmuxInjectorForTesting(() => {
+      throw new Error('tmux session crashed');
+    });
+
+    const result = sendMessage({
+      from: 'orchestrator',
+      to: 'comms',
+      type: 'text',
+      body: 'This should not cause a 500',
+      direct: true,
+    });
+
+    // Message was stored — routing error is non-fatal
+    assert.equal(result.delivered, false);
+
+    // Message exists in DB
+    const messages = query<Message>('SELECT * FROM messages WHERE id = ?', result.messageId);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].body, 'This should not cause a 500');
+  });
+
+  it('POST /api/messages returns 200 even when routing throws (issue #25)', async () => {
+    _setTmuxInjectorForTesting(() => {
+      throw new Error('relay forwarding failed');
+    });
+
+    const res = await request('POST', '/api/messages', {
+      from: 'comms',
+      to: 'orchestrator',
+      type: 'task',
+      body: 'Message that triggers routing error',
+      direct: true,
+    });
+
+    // Should NOT be a 500
+    assert.equal(res.status, 200);
+    const body = JSON.parse(res.body);
+    assert.ok(typeof body.messageId === 'number');
+    assert.equal(body.delivered, false);
+  });
+
   it('POST /api/messages with direct=true passes through to sendMessage', async () => {
     const injected: { session: string; text: string }[] = [];
     _setTmuxInjectorForTesting((session, text) => {

--- a/daemon/src/agents/message-router.ts
+++ b/daemon/src/agents/message-router.ts
@@ -133,31 +133,42 @@ export function sendMessage(req: SendMessageRequest): { messageId: number; deliv
     }
   }
 
-  // Route to target
-  if (isPersistentAgent(req.to)) {
-    // Direct channel: bypass scheduler and inject immediately
-    if (req.direct) {
-      const formatted = formatForTmux(req);
-      const injected = tmuxInjector(req.to, formatted);
-      if (injected) {
-        // Mark as processed — deliver-once, no re-notification
-        exec(
-          'UPDATE messages SET processed_at = ? WHERE id = ?',
-          new Date().toISOString(), message.id,
-        );
-        return { messageId: message.id, delivered: true };
+  // Route to target — wrapped in try/catch so routing failures never
+  // bubble up as 500s.  The message is already persisted; delivery
+  // failures are non-fatal and can be retried by the scheduler.
+  try {
+    if (isPersistentAgent(req.to)) {
+      // Direct channel: bypass scheduler and inject immediately
+      if (req.direct) {
+        const formatted = formatForTmux(req);
+        const injected = tmuxInjector(req.to, formatted);
+        if (injected) {
+          // Mark as processed — deliver-once, no re-notification
+          exec(
+            'UPDATE messages SET processed_at = ? WHERE id = ?',
+            new Date().toISOString(), message.id,
+          );
+          return { messageId: message.id, delivered: true };
+        }
+        // Injection failed (session not alive) — fall through to normal delivery
       }
-      // Injection failed (session not alive) — fall through to normal delivery
-    }
 
-    // Queue for delivery — the message-delivery scheduler task handles tmux injection.
-    // Trigger the task immediately so delivery doesn't wait for the next interval tick.
-    notifyNewMessage();
+      // Queue for delivery — the message-delivery scheduler task handles tmux injection.
+      // Trigger the task immediately so delivery doesn't wait for the next interval tick.
+      notifyNewMessage();
+      return { messageId: message.id, delivered: false };
+    }
+    // Workers pull their own messages — no active delivery needed
+
+    return { messageId: message.id, delivered: true };
+  } catch (err) {
+    log.warn('Message routing failed after storage — delivery will be retried', {
+      messageId: message.id,
+      to: req.to,
+      error: err instanceof Error ? err.message : String(err),
+    });
     return { messageId: message.id, delivered: false };
   }
-  // Workers pull their own messages — no active delivery needed
-
-  return { messageId: message.id, delivered: true };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wraps the post-storage routing block in `sendMessage()` (`message-router.ts`) with try/catch
- If tmux injection or scheduler notification throws after the message is persisted in SQLite, the error is logged as a warning and `delivered: false` is returned instead of propagating as a 500
- Adds two regression tests: one at the `sendMessage()` level and one at the HTTP endpoint level

Closes #25

## What changed
**`daemon/src/agents/message-router.ts`** — The routing logic (tmux injection for persistent agents, scheduler notification) is now wrapped in try/catch. On failure, logs a warning with messageId, target agent, and error message, then returns `{ messageId, delivered: false }`.

**`daemon/src/__tests__/message-router.test.ts`** — Two new tests:
1. `direct=true returns delivered:false (not 500) when tmux injector throws` — verifies `sendMessage()` catches routing errors
2. `POST /api/messages returns 200 even when routing throws (issue #25)` — verifies the HTTP endpoint returns 200 instead of 500

## Test plan
- [ ] Existing message router tests pass (note: all tests have a pre-existing `SQLITE_CONSTRAINT_PRIMARYKEY` failure in test setup on main — tracked separately)
- [ ] New regression tests cover the exact failure scenario from issue #25
- [ ] Manual: send a message to a persistent agent when tmux session is down — should get 200 with `delivered: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)