### PR TITLE
Fix A2A message double-wrapping on direct injection

### DIFF
--- a/daemon/src/agents/message-router.ts
+++ b/daemon/src/agents/message-router.ts
@@ -135,10 +135,12 @@ export function sendMessage(req: SendMessageRequest): { messageId: number; deliv
 
   // Route to target
   if (isPersistentAgent(req.to)) {
-    // Direct channel: bypass scheduler and inject immediately
+    // Direct channel: bypass scheduler and inject immediately.
+    // Use body as-is — callers that set direct=true (agent-comms, sdk-bridge)
+    // have already formatted the display text (e.g. "[Agent] R2d2: message").
+    // Applying formatForTmux on top would double-wrap the prefix.
     if (req.direct) {
-      const formatted = formatForTmux(req);
-      const injected = tmuxInjector(req.to, formatted);
+      const injected = tmuxInjector(req.to, req.body);
       if (injected) {
         // Mark as processed — deliver-once, no re-notification
         exec(


### PR DESCRIPTION
## Summary

- `sendMessage({ body: formatted, direct: true })` was calling `formatForTmux()` which added `[text] from lan:r2d2:` prefix on top of a body already formatted as `[Agent] R2d2: message`
- Callers in `agent-comms.ts` and `sdk-bridge.ts` pre-format the body with display prefix before calling `sendMessage` with `direct: true`
- The double-wrapping showed as: `[text] from lan:r2d2: [Agent] R2d2: [Status: idle]` in the target agent's terminal

**Fix**: when `direct=true`, inject `req.body` as-is instead of calling `formatForTmux`. The callers that use `direct=true` have already formatted the display text.

**Observed by**: Dave (screenshot of BMO's terminal showing the double-wrapped message)

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] A2A messages from peer agents show clean format: `[Agent] R2d2: message` not `[text] from lan:r2d2: [Agent] R2d2: message`
- [ ] Network relay messages show clean format: `[Network] Name: text` not `[text] from network:name: [Network] Name: text`

🤖 Generated with [Claude Code](https://claude.com/claude-code)