### PR TITLE
Fix JMAP email credential resolution

### DIFF
--- a/daemon/src/extensions/comms/adapters/email/jmap-provider.ts
+++ b/daemon/src/extensions/comms/adapters/email/jmap-provider.ts
@@ -50,10 +50,9 @@ interface JmapCredentials {
 }
 
 async function getJmapCredentials(): Promise<JmapCredentials> {
-  const [token, email] = await Promise.all([
-    readKeychain('credential-fastmail-token'),
-    readKeychain('credential-fastmail-email'),
-  ]);
+  const token = await readKeychain('credential-fastmail-api');
+  // Email is optional in keychain — falls back to owner_email in config
+  const email = await readKeychain('credential-fastmail-email');
   return { token, email };
 }
 
@@ -81,6 +80,11 @@ export class BmoJmapAdapter implements ChannelAdapter {
 
   private _creds: JmapCredentials | null = null;
   private _inboundBuffer: InboundMessage[] = [];
+  private _fallbackEmail: string | null;
+
+  constructor(fallbackEmail?: string) {
+    this._fallbackEmail = fallbackEmail ?? null;
+  }
 
   /** Check if JMAP credentials are available in Keychain. */
   async isConfigured(): Promise<boolean> {
@@ -358,7 +362,14 @@ export class BmoJmapAdapter implements ChannelAdapter {
   // ── Internals ─────────────────────────────────────────────
 
   private async _getCreds(): Promise<JmapCredentials> {
-    if (!this._creds) this._creds = await getJmapCredentials();
+    if (!this._creds) {
+      const creds = await getJmapCredentials();
+      // Fall back to constructor-provided email if not in keychain
+      if (!creds.email && this._fallbackEmail) {
+        creds.email = this._fallbackEmail;
+      }
+      this._creds = creds;
+    }
     return this._creds;
   }
 

--- a/daemon/src/extensions/comms/index.ts
+++ b/daemon/src/extensions/comms/index.ts
@@ -70,7 +70,8 @@ export async function initComms(config: R2Config): Promise<void> {
             break;
           }
           case 'jmap': {
-            _jmapAdapter = new BmoJmapAdapter();
+            const ownerEmail = config.network?.owner_email;
+            _jmapAdapter = new BmoJmapAdapter(ownerEmail);
             if (await _jmapAdapter.isConfigured()) {
               registerEmailAdapter(_jmapAdapter);
               log.info('JMAP email adapter enabled');


### PR DESCRIPTION
## Summary

Fixes #50 — Email JMAP delivery was broken because the adapter couldn't resolve Fastmail credentials from the macOS keychain.

**Root causes:**
- The JMAP adapter looked up `credential-fastmail-token` from keychain, but the actual entry is stored as `credential-fastmail-api`
- The sender email address was required from keychain as `credential-fastmail-email`, but was never stored there — it lives in `kithkit.config.yaml` as `network.owner_email`
- The `kithkit.config.yaml` had no `channels.email` section, so the email adapter initialization was skipped entirely (deployment config fix, not in this PR)

**Changes:**
- Fix keychain service name lookup (`credential-fastmail-token` → `credential-fastmail-api`)
- Add `fallbackEmail` constructor parameter to `BmoJmapAdapter` for config-based email resolution
- Pass `network.owner_email` from config when initializing the JMAP adapter

## Test plan

- [x] Verified JMAP auth succeeds with correct keychain credential name
- [x] Verified `BmoJmapAdapter.isConfigured()` returns `true`
- [x] Verified `listInbox()` successfully returns emails from Fastmail
- [x] Existing channel-adapter tests pass (pre-existing SQLite test setup failures unrelated)
- [ ] Restart daemon with email channel enabled in config and verify JMAP adapter registers

🤖 Generated with [Claude Code](https://claude.com/claude-code)