### PR TITLE
Fix #24: wake orchestrator for pending tasks instead of idle shutdown

### DIFF
--- a/daemon/src/__tests__/orchestrator-idle.test.ts
+++ b/daemon/src/__tests__/orchestrator-idle.test.ts
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
-import { openDatabase, closeDatabase, _resetDbForTesting, insert, update, query } from '../core/db.js';
+import { openDatabase, closeDatabase, _resetDbForTesting, insert, update, query, exec } from '../core/db.js';
 import { _resetConfigForTesting, loadConfig } from '../core/config.js';
 import {
   _resetNudgeStateForTesting,
@@ -226,5 +226,35 @@ describe('Orchestrator idle: liveness check', () => {
     const state = _getNudgeStateForTesting();
     assert.notEqual(state.nudgedAt, null, 'should have set nudge state');
     assert.ok(injectedText.includes('Shutdown requested'), 'should inject shutdown prompt');
+  });
+
+  it('wakes orchestrator with task notification instead of shutdown when pending tasks exist', async () => {
+    let injectedText = '';
+    _setDepsForTesting({
+      isOrchestratorAlive: () => true,
+      killOrchestratorSession: () => { throw new Error('should not kill'); },
+      injectMessage: (_target: string, text: string) => { injectedText = text; return true; },
+      cleanupSessionDirs: () => 0,
+    });
+
+    // Set last_activity to 15 minutes ago (past 10 min default)
+    update('agents', 'orchestrator', {
+      last_activity: new Date(Date.now() - 15 * 60_000).toISOString(),
+    });
+
+    // Insert a pending orchestrator task
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, description, status, priority, created_at, updated_at)
+       VALUES ('test-task-idle-1', 'Fix the login bug', 'description', 'pending', 0, ?, ?)`,
+      new Date().toISOString(), new Date().toISOString(),
+    );
+
+    await _runForTesting({});
+
+    const state = _getNudgeStateForTesting();
+    assert.equal(state.nudgedAt, null, 'should NOT set shutdown nudge state');
+    assert.ok(injectedText.includes('pending task'), 'should inject task notification not shutdown');
+    assert.ok(injectedText.includes('Fix the login bug'), 'should include task title');
+    assert.ok(!injectedText.includes('Shutdown requested'), 'should NOT inject shutdown prompt');
   });
 });

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -288,6 +288,38 @@ async function run(config: Record<string, unknown>): Promise<void> {
     return; // Not idle long enough
   }
 
+  // --- Check 3: Pending tasks ---
+  // Before nudging shutdown, check if there are tasks waiting in the queue.
+  // If so, wake the orchestrator with a task notification instead of shutting it down.
+  // This covers the case where a task arrived while Claude was active and the
+  // orchestrator went idle before the message-delivery cycle injected it.
+  const pendingTaskRows = query<{ count: number; title: string }>(
+    `SELECT COUNT(*) as count, MIN(title) as title FROM orchestrator_tasks
+     WHERE status = 'pending'`,
+  );
+  const pendingTaskCount = pendingTaskRows[0]?.count ?? 0;
+  if (pendingTaskCount > 0) {
+    const taskTitle = pendingTaskRows[0]?.title ?? 'unknown';
+    const wakeMsg = pendingTaskCount === 1
+      ? `You have 1 pending task: "${taskTitle}" — check GET /api/orchestrator/tasks?status=pending`
+      : `You have ${pendingTaskCount} pending tasks — check GET /api/orchestrator/tasks?status=pending`;
+    log.info('Orchestrator idle but has pending tasks — waking instead of shutdown', { pendingTaskCount });
+    const injected = injectMessage('orchestrator', wakeMsg);
+    if (injected) {
+      // Touch last_activity so we don't immediately re-trigger
+      update('agents', 'orchestrator', {
+        last_activity: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      });
+      logActivity({
+        agent_id: 'orchestrator',
+        event_type: 'task_received',
+        details: `Woken for ${pendingTaskCount} pending task(s): ${taskTitle}`,
+      });
+    }
+    return;
+  }
+
   const reason = `idle for ${Math.round(idleMs / 60000)} minutes — Claude process not running, no pending work`;
   log.info('Orchestrator idle — sending shutdown nudge', { idleMinutes: Math.round(idleMs / 60000) });
   const injected = injectMessage('orchestrator', buildShutdownPrompt(reason));


### PR DESCRIPTION
## Summary

- Adds **Check 3: Pending tasks** to `orchestrator-idle.ts` — runs after idle timeout check, before sending shutdown nudge
- If `orchestrator_tasks` has any `pending` rows, injects a task notification message instead of the shutdown prompt (wakes the orchestrator to do the work)
- Touches `last_activity` after waking to prevent immediate re-trigger
- Adds unit test covering the new wake-instead-of-shutdown path

## Motivation

Closes the last significant gap from issue #24: the idle monitor claimed there was "no pending work" without ever querying the `orchestrator_tasks` table. A task posted while the orchestrator was idle but still alive would never get picked up — the next cycle would shut the orchestrator down instead of waking it.

## Test plan

- [ ] New test `'wakes orchestrator with task notification instead of shutdown when pending tasks exist'` passes
- [ ] Existing nudge/grace/liveness tests still pass
- [ ] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)