### PR TITLE
Fix #70: task auto-complete matches wrong result to task

### DIFF
--- a/daemon/src/__tests__/message-router.test.ts
+++ b/daemon/src/__tests__/message-router.test.ts
@@ -571,3 +571,86 @@ describe('Direct channel — immediate delivery for persistent agents', () => {
     assert.equal(injected.length, 1);
   });
 });
+
+describe('Auto-complete orchestrator task on result message (#70)', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  function createTask(id: string, status: string, createdAt: string): void {
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, status, priority, created_at, updated_at)
+       VALUES (?, ?, ?, 0, ?, ?)`,
+      id, `Task ${id}`, status, createdAt, createdAt,
+    );
+  }
+
+  it('completes in_progress task over newer pending task', () => {
+    // Task A: older, in_progress (should be matched)
+    createTask('task-a', 'in_progress', '2026-01-01T00:00:00Z');
+    // Task B: newer, pending (should NOT be matched)
+    createTask('task-b', 'pending', '2026-01-02T00:00:00Z');
+
+    sendMessage({
+      from: 'orchestrator',
+      to: 'comms',
+      type: 'result',
+      body: 'Result for task A',
+    });
+
+    const taskA = query<{ status: string }>('SELECT status FROM orchestrator_tasks WHERE id = ?', 'task-a');
+    const taskB = query<{ status: string }>('SELECT status FROM orchestrator_tasks WHERE id = ?', 'task-b');
+    assert.equal(taskA[0]!.status, 'completed', 'in_progress task should be completed');
+    assert.equal(taskB[0]!.status, 'pending', 'pending task should remain pending');
+  });
+
+  it('matches by metadata.task_id when provided', () => {
+    createTask('task-a', 'in_progress', '2026-01-01T00:00:00Z');
+    createTask('task-b', 'pending', '2026-01-02T00:00:00Z');
+
+    sendMessage({
+      from: 'orchestrator',
+      to: 'comms',
+      type: 'result',
+      body: 'Result for task B',
+      metadata: { task_id: 'task-b' },
+    });
+
+    const taskA = query<{ status: string }>('SELECT status FROM orchestrator_tasks WHERE id = ?', 'task-a');
+    const taskB = query<{ status: string }>('SELECT status FROM orchestrator_tasks WHERE id = ?', 'task-b');
+    assert.equal(taskA[0]!.status, 'in_progress', 'task A should remain in_progress');
+    assert.equal(taskB[0]!.status, 'completed', 'task B should be completed via metadata match');
+  });
+
+  it('falls back to FIFO when no in_progress task exists', () => {
+    // Both pending — oldest should be completed first
+    createTask('task-old', 'pending', '2026-01-01T00:00:00Z');
+    createTask('task-new', 'pending', '2026-01-02T00:00:00Z');
+
+    sendMessage({
+      from: 'orchestrator',
+      to: 'comms',
+      type: 'result',
+      body: 'Some result',
+    });
+
+    const taskOld = query<{ status: string }>('SELECT status FROM orchestrator_tasks WHERE id = ?', 'task-old');
+    const taskNew = query<{ status: string }>('SELECT status FROM orchestrator_tasks WHERE id = ?', 'task-new');
+    assert.equal(taskOld[0]!.status, 'completed', 'oldest pending task should be completed');
+    assert.equal(taskNew[0]!.status, 'pending', 'newer pending task should remain');
+  });
+
+  it('does not match already-completed tasks', () => {
+    createTask('task-done', 'completed', '2026-01-01T00:00:00Z');
+    createTask('task-active', 'in_progress', '2026-01-02T00:00:00Z');
+
+    sendMessage({
+      from: 'orchestrator',
+      to: 'comms',
+      type: 'result',
+      body: 'New result',
+    });
+
+    const taskActive = query<{ status: string }>('SELECT status FROM orchestrator_tasks WHERE id = ?', 'task-active');
+    assert.equal(taskActive[0]!.status, 'completed');
+  });
+});

--- a/daemon/src/agents/message-router.ts
+++ b/daemon/src/agents/message-router.ts
@@ -117,18 +117,39 @@ export function sendMessage(req: SendMessageRequest): { messageId: number; deliv
   // Auto-complete orchestrator task when orchestrator sends a result message
   if (req.from === 'orchestrator' && req.type === 'result') {
     try {
-      const rows = query<{ id: string }>(
-        `SELECT id FROM orchestrator_tasks
-         WHERE status IN ('assigned', 'in_progress', 'pending')
-         ORDER BY created_at DESC LIMIT 1`,
-      );
-      if (rows.length > 0) {
+      let taskId: string | undefined;
+
+      // Prefer exact match via metadata.task_id if provided
+      if (req.metadata?.task_id && typeof req.metadata.task_id === 'string') {
+        const exact = query<{ id: string }>(
+          `SELECT id FROM orchestrator_tasks
+           WHERE id = ? AND status IN ('assigned', 'in_progress', 'pending')`,
+          req.metadata.task_id,
+        );
+        if (exact.length > 0) taskId = exact[0]!.id;
+      }
+
+      // Fallback: prefer in_progress tasks (FIFO by creation order)
+      if (!taskId) {
+        const rows = query<{ id: string }>(
+          `SELECT id FROM orchestrator_tasks
+           WHERE status IN ('assigned', 'in_progress', 'pending')
+           ORDER BY CASE status
+             WHEN 'in_progress' THEN 0
+             WHEN 'assigned' THEN 1
+             WHEN 'pending' THEN 2
+           END, created_at ASC LIMIT 1`,
+        );
+        if (rows.length > 0) taskId = rows[0]!.id;
+      }
+
+      if (taskId) {
         const now = new Date().toISOString();
         exec(
           `UPDATE orchestrator_tasks SET status = 'completed', result = ?, completed_at = ?, updated_at = ? WHERE id = ?`,
-          req.body.slice(0, 5000), now, now, rows[0]!.id,
+          req.body.slice(0, 5000), now, now, taskId,
         );
-        log.info('Auto-completed orchestrator task on result message', { taskId: rows[0]!.id });
+        log.info('Auto-completed orchestrator task on result message', { taskId });
       }
     } catch (err) {
       log.warn('Failed to auto-complete orchestrator task', {

--- a/daemon/src/api/orchestrator.ts
+++ b/daemon/src/api/orchestrator.ts
@@ -289,7 +289,7 @@ async function buildOrchestratorPrompt(task: string, context?: string, sessionDi
     '- Output structured results, not conversational prose',
     '- Spawn workers via POST http://localhost:3847/api/agents/spawn (profiles: research, coding, testing)',
     '- Check worker status via GET http://localhost:3847/api/agents/:id/status',
-    '- Report results to comms via: curl -s -X POST http://localhost:3847/api/messages -H "Content-Type: application/json" -d \'{"from":"orchestrator","to":"comms","type":"result","body":"<your result>"}\'',
+    '- Report results to comms via: curl -s -X POST http://localhost:3847/api/messages -H "Content-Type: application/json" -d \'{"from":"orchestrator","to":"comms","type":"result","body":"<your result>","metadata":{"task_id":"<task-id>"}}\'',
     '- When a task is complete, send a result message to comms and wait for the next task',
     '- If the daemon sends you a shutdown nudge (idle timeout), wrap up gracefully: send any unsent context to comms, then exit',
     '- Do not interact with the human directly — only comms talks to humans',


### PR DESCRIPTION
## Summary
- **Bug**: The auto-complete logic in `message-router.ts` used `ORDER BY created_at DESC`, which matched the *newest* task instead of the one being worked on. When multiple tasks were in flight, results got attributed to the wrong task.
- **Fix**: Prefer exact match via `metadata.task_id` when the orchestrator includes it in result messages. Fall back to status-priority ordering (`in_progress` > `assigned` > `pending`) with FIFO (`created_at ASC`) within each tier.
- **Prompt update**: The orchestrator's prompt template now includes `metadata.task_id` in the result message example, so orchestrators will include it going forward.
- **Tests**: 4 new tests covering metadata match, status priority, FIFO fallback, and completed-task exclusion.

Closes #70

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [ ] Verify auto-complete picks `in_progress` task when multiple tasks exist
- [ ] Verify `metadata.task_id` exact matching works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)