### PR TITLE
Fix #78: update session-start hook to use kithkit.config.yaml

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -105,8 +105,8 @@ echo "---"
 if [ "${CC4ME_QUIET_START:-0}" != "1" ]; then
   TMUX_BIN="/opt/homebrew/bin/tmux"
   TMUX_SOCKET="/private/tmp/tmux-$(id -u)/default"
-  SESSION_NAME=$(grep -A1 '^tmux:' "$PROJECT_DIR/cc4me.config.yaml" 2>/dev/null | grep 'session:' | sed 's/.*session:[[:space:]]*//' | tr -d '"' | tr -d "'")
-  SESSION_NAME="${SESSION_NAME:-cc4me}"
+  SESSION_NAME=$(grep -A1 '^tmux:' "$PROJECT_DIR/kithkit.config.yaml" 2>/dev/null | grep 'session:' | sed 's/.*session:[[:space:]]*//' | tr -d '"' | tr -d "'")
+  SESSION_NAME="${SESSION_NAME:-comms1}"
 
   if [ "$SOURCE" = "clear" ] || [ "$SOURCE" = "compact" ]; then
     PROMPT="Session cleared and restored. Pick up where you left off."


### PR DESCRIPTION
## Summary
- Update config filename reference from `cc4me.config.yaml` to `kithkit.config.yaml`
- Update fallback session name from `cc4me` to `comms1`

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)