### PR TITLE
Fix #80: route home group chat messages to comms agent

### DIFF
--- a/daemon/src/extensions/comms/adapters/telegram.ts
+++ b/daemon/src/extensions/comms/adapters/telegram.ts
@@ -683,10 +683,26 @@ export class BmoTelegramAdapter implements ChannelAdapter {
     const ctx = extractMessageContext(msg, token);
     if (ctx.isSelf) return;
 
-    _replyChatId = ctx.replyChatId;
-    persistReplyChatId(ctx.replyChatId);
-
     const { senderId, replyChatId, firstName, chatType } = ctx;
+    const isGroup = chatType === 'group' || chatType === 'supergroup';
+
+    if (isGroup) {
+      // Only process messages from the configured home group
+      const rawConfig = loadConfig() as unknown as Record<string, unknown>;
+      const channels = rawConfig.channels as Record<string, unknown> | undefined;
+      const telegramConfig = channels?.telegram as Record<string, unknown> | undefined;
+      const homeGroupId = telegramConfig?.home_group_chat_id != null ? String(telegramConfig.home_group_chat_id) : null;
+
+      if (!homeGroupId || replyChatId !== homeGroupId) {
+        log.debug(`Ignoring message from non-home group: ${replyChatId}`);
+        return;
+      }
+      // Don't overwrite _replyChatId — preserve DM reply context
+    } else {
+      // DM: update reply context as before
+      _replyChatId = ctx.replyChatId;
+      persistReplyChatId(ctx.replyChatId);
+    }
 
     // Track that Telegram is the last active text channel (for voice response routing)
     updateLastActiveChannel('telegram');


### PR DESCRIPTION
## Summary
- Filter group messages: only process messages from the configured `home_group_chat_id` in kithkit.config.yaml. Messages from other groups are silently dropped.
- Preserve DM reply context: don't overwrite `_replyChatId` for group messages, so responses continue going to DMs.
- Add `home_group_chat_id` config field under `channels.telegram`.

Builds on #85 (issue #79) which added the `[Telegram - group:<id>]` prefix.

Closes #80

## Test plan
- [ ] Send a message in the home-agents group — verify it gets injected with `[Telegram - group:<id>]` prefix
- [ ] Send a message in a different group — verify it's silently dropped
- [ ] After receiving a group message, send a DM — verify response goes to DM (not the group)
- [ ] Verify `_replyChatId` file is not overwritten by group messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)