### PR TITLE
Fix branch-guard hook: remove matcher for cross-version compat

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,9 +16,6 @@
         ]
       },
       {
-        "matcher": {
-          "tool_name": "Bash"
-        },
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- R2 flagged the `matcher` object on the `branch-guard` `PreToolUse` hook as incompatible across Claude Code versions
- The `matcher: { tool_name: "Bash" }` field was introduced in PR #76 but is not supported in all deployed versions of Claude Code
- This removes the `matcher` object entirely and lets `branch-guard.sh` handle its own internal filtering, matching the format used in KKit-BMO

## Changes

- `.claude/settings.json`: removed `matcher: { tool_name: "Bash" }` from the `branch-guard` `PreToolUse` hook entry

## Test plan

- [ ] Verify `settings.json` is valid JSON after the change
- [ ] Confirm `branch-guard.sh` still fires on `PreToolUse` (no matcher means it runs on all tool calls, script filters internally)
- [ ] Confirm no regression on older Claude Code versions that don't support the `matcher` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)