### PR TITLE
fix: remove matcher from branch-guard hook for cross-version compat

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,9 +16,6 @@
         ]
       },
       {
-        "matcher": {
-          "tool_name": "Bash"
-        },
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Removes `matcher` object from PreToolUse branch-guard hook entry in `.claude/settings.json`
- The `matcher.tool_name` field is not compatible with all Claude Code versions
- The branch-guard.sh script already checks tool_name internally from stdin JSON, so the matcher is redundant

Follow-up to #76.

## Test plan
- [ ] Verify branch-guard still blocks `git checkout feature-branch` in comms/orchestrator
- [ ] Verify branch-guard allows `git checkout main`, `git checkout .`, etc.
- [ ] Verify hook runs on all PreToolUse events (not just Bash) and exits cleanly for non-Bash tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)