### PR TITLE
Fix orchestrator reliability: zombie cleanup, completion notifications, timeouts (#95)

### DIFF
--- a/daemon/src/__tests__/orchestrator-idle.test.ts
+++ b/daemon/src/__tests__/orchestrator-idle.test.ts
@@ -154,6 +154,118 @@ describe('Orchestrator idle: graceful exit logging', () => {
   });
 });
 
+describe('Orchestrator idle: zombie task cleanup', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = setupTestEnv();
+  });
+
+  afterEach(() => {
+    cleanupTestEnv(tmpDir);
+  });
+
+  it('marks in_progress tasks as failed when orchestrator dies after nudge', async () => {
+    // Insert an in_progress task
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, description, status, priority, created_at, updated_at)
+       VALUES ('zombie-task-1', 'In-progress task', null, 'in_progress', 0, ?, ?)`,
+      new Date().toISOString(), new Date().toISOString(),
+    );
+
+    // Simulate: nudge was sent, orchestrator has since exited
+    _setNudgeStateForTesting(Date.now() - 10_000, 'idle timeout');
+    _setDepsForTesting({
+      isOrchestratorAlive: () => false,
+      killOrchestratorSession: () => { throw new Error('should not be called'); },
+      injectMessage: () => { throw new Error('should not be called'); },
+      cleanupSessionDirs: () => 0,
+    });
+
+    await _runForTesting({});
+
+    // Task should now be failed
+    const tasks = query<{ id: string; status: string; error: string }>(
+      `SELECT id, status, error FROM orchestrator_tasks WHERE id = 'zombie-task-1'`,
+    );
+    assert.equal(tasks.length, 1);
+    assert.equal(tasks[0]!.status, 'failed', 'zombie task should be marked failed');
+    assert.equal(tasks[0]!.error, 'orchestrator_died', 'error should indicate orchestrator death');
+  });
+
+  it('marks assigned tasks as failed when orchestrator is dead with no nudge', async () => {
+    // Insert an assigned task
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, description, status, assignee, priority, created_at, updated_at)
+       VALUES ('zombie-task-2', 'Assigned task', null, 'assigned', 'orchestrator', 0, ?, ?)`,
+      new Date().toISOString(), new Date().toISOString(),
+    );
+
+    _setDepsForTesting({
+      isOrchestratorAlive: () => false,
+      killOrchestratorSession: () => false,
+      injectMessage: () => false,
+      cleanupSessionDirs: () => 0,
+    });
+
+    await _runForTesting({});
+
+    const tasks = query<{ id: string; status: string; error: string }>(
+      `SELECT id, status, error FROM orchestrator_tasks WHERE id = 'zombie-task-2'`,
+    );
+    assert.equal(tasks.length, 1);
+    assert.equal(tasks[0]!.status, 'failed', 'assigned zombie task should be marked failed');
+    assert.equal(tasks[0]!.error, 'orchestrator_died');
+  });
+
+  it('logs activity for each zombie task cleaned up', async () => {
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, description, status, priority, created_at, updated_at)
+       VALUES ('zombie-task-3', 'Another zombie', null, 'in_progress', 0, ?, ?)`,
+      new Date().toISOString(), new Date().toISOString(),
+    );
+
+    _setDepsForTesting({
+      isOrchestratorAlive: () => false,
+      killOrchestratorSession: () => false,
+      injectMessage: () => false,
+      cleanupSessionDirs: () => 0,
+    });
+
+    await _runForTesting({});
+
+    const activity = query<{ task_id: string; stage: string; message: string }>(
+      `SELECT task_id, stage, message FROM orchestrator_task_activity WHERE task_id = 'zombie-task-3'`,
+    );
+    assert.ok(activity.length > 0, 'should have logged activity for zombie task');
+    assert.equal(activity[0]!.stage, 'cleanup');
+    assert.ok(activity[0]!.message.includes('orchestrator died'), `message: ${activity[0]!.message}`);
+  });
+
+  it('does not touch completed or failed tasks during zombie cleanup', async () => {
+    // Insert a completed task — should remain completed
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, status, priority, created_at, updated_at)
+       VALUES ('completed-task-1', 'Already done', 'completed', 0, ?, ?)`,
+      new Date().toISOString(), new Date().toISOString(),
+    );
+
+    _setDepsForTesting({
+      isOrchestratorAlive: () => false,
+      killOrchestratorSession: () => false,
+      injectMessage: () => false,
+      cleanupSessionDirs: () => 0,
+    });
+
+    await _runForTesting({});
+
+    const tasks = query<{ status: string }>(
+      `SELECT status FROM orchestrator_tasks WHERE id = 'completed-task-1'`,
+    );
+    assert.equal(tasks[0]!.status, 'completed', 'completed task should not be touched by zombie cleanup');
+  });
+});
+
 describe('Orchestrator idle: liveness check', () => {
   let tmpDir: string;
 

--- a/daemon/src/__tests__/task-queue.test.ts
+++ b/daemon/src/__tests__/task-queue.test.ts
@@ -11,7 +11,7 @@ import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { openDatabase, _resetDbForTesting } from '../core/db.js';
+import { openDatabase, _resetDbForTesting, query } from '../core/db.js';
 import { handleTaskQueueRoute } from '../api/task-queue.js';
 
 const TEST_PORT = 19870;
@@ -532,6 +532,135 @@ describe('Task Queue API', { concurrency: 1 }, () => {
       const listRes = await request('GET', '/api/orchestrator/tasks?status=pending');
       const body = JSON.parse(listRes.body);
       assert.equal(body.data.length, 5);
+    });
+  });
+
+  // ── Auto-activity on status change (Fix 4) ─────────────────
+
+  describe('Auto-activity log on status change', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('auto-logs activity when task transitions to assigned', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+
+      const actRes = await request('GET', `/api/orchestrator/tasks/${task.id}/activity`);
+      const actBody = JSON.parse(actRes.body);
+      const statusChanges = actBody.data.filter((a: { stage: string }) => a.stage === 'status_change');
+      assert.ok(statusChanges.length > 0, 'should have auto-logged a status_change activity');
+      assert.ok(statusChanges[0].message.includes('assigned'), `message: ${statusChanges[0].message}`);
+    });
+
+    it('auto-logs activity with result when task completes', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'completed', result: 'All tasks completed successfully',
+      });
+
+      const actRes = await request('GET', `/api/orchestrator/tasks/${task.id}/activity`);
+      const actBody = JSON.parse(actRes.body);
+      const completionLog = actBody.data.find(
+        (a: { stage: string; message: string }) => a.stage === 'status_change' && a.message.includes('completed'),
+      );
+      assert.ok(completionLog, 'should have auto-logged completion activity');
+      assert.ok(completionLog.message.includes('All tasks completed'), `message: ${completionLog.message}`);
+    });
+
+    it('auto-logs activity with error when task fails', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'failed', error: 'Worker crashed unexpectedly',
+      });
+
+      const actRes = await request('GET', `/api/orchestrator/tasks/${task.id}/activity`);
+      const actBody = JSON.parse(actRes.body);
+      const failureLog = actBody.data.find(
+        (a: { stage: string; message: string }) => a.stage === 'status_change' && a.message.includes('failed'),
+      );
+      assert.ok(failureLog, 'should have auto-logged failure activity');
+      assert.ok(failureLog.message.includes('Worker crashed'), `message: ${failureLog.message}`);
+    });
+  });
+
+  // ── Auto-notification to comms on completion (Fix 2) ───────
+
+  describe('Auto-notification to comms on task completion', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('sends a message to comms when task completes', async () => {
+      const task = await createTask({ title: 'Deploy feature X' });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'completed', result: 'Feature deployed to staging',
+      });
+
+      // Check the messages table for auto-notification
+      const msgs = query<{ from_agent: string; to_agent: string; type: string; body: string }>(
+        `SELECT from_agent, to_agent, type, body FROM messages WHERE to_agent = 'comms' AND from_agent = 'daemon'`,
+      );
+      assert.ok(msgs.length > 0, 'should have sent a message to comms');
+      const completionMsg = msgs.find(m => m.body.includes('Deploy feature X'));
+      assert.ok(completionMsg, 'message should include task title');
+      assert.ok(completionMsg!.body.includes('Feature deployed to staging'), 'message should include result');
+      assert.equal(completionMsg!.type, 'result');
+    });
+
+    it('sends a message to comms when task fails', async () => {
+      const task = await createTask({ title: 'Run integration tests' });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'failed', error: 'Tests timed out',
+      });
+
+      const msgs = query<{ from_agent: string; to_agent: string; type: string; body: string }>(
+        `SELECT from_agent, to_agent, type, body FROM messages WHERE to_agent = 'comms' AND from_agent = 'daemon'`,
+      );
+      assert.ok(msgs.length > 0, 'should have sent a message to comms on failure');
+      const failureMsg = msgs.find(m => m.body.includes('Run integration tests'));
+      assert.ok(failureMsg, 'message should include task title');
+      assert.ok(failureMsg!.body.includes('Tests timed out'), 'message should include error detail');
+    });
+
+    it('does not send comms message on non-terminal status transitions', async () => {
+      const task = await createTask({ title: 'Background work' });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'in_progress',
+      });
+
+      // No completion — check no messages sent
+      const msgs = query<{ id: number }>(
+        `SELECT id FROM messages WHERE to_agent = 'comms' AND from_agent = 'daemon'`,
+      );
+      assert.equal(msgs.length, 0, 'should NOT send comms message for non-terminal transitions');
     });
   });
 });

--- a/daemon/src/__tests__/tmux.test.ts
+++ b/daemon/src/__tests__/tmux.test.ts
@@ -151,6 +151,47 @@ describe('buildOrchestratorWrapperScript — task extraction logic', () => {
   });
 });
 
+describe('buildOrchestratorWrapperScript — robust task status transitions (Fix 5)', () => {
+  it('checks HTTP status code before marking task in_progress', () => {
+    const script = buildOrchestratorWrapperScript('/usr/bin/claude', 'Task');
+    // Should capture HTTP response code for the assign step
+    assert.ok(
+      script.includes("ASSIGN_OK="),
+      'should capture assign HTTP status code in ASSIGN_OK variable',
+    );
+    assert.ok(
+      script.includes('-w \'%{http_code}\''),
+      'should use curl -w to capture HTTP status code',
+    );
+  });
+
+  it('skips in_progress transition when assign fails', () => {
+    const script = buildOrchestratorWrapperScript('/usr/bin/claude', 'Task');
+    // Should check ASSIGN_OK before transitioning to in_progress
+    assert.ok(
+      script.includes('if [ "$ASSIGN_OK" = "200" ]'),
+      'should only transition to in_progress if assign returned HTTP 200',
+    );
+    assert.ok(
+      script.includes('WARN: Failed to assign task'),
+      'should log a warning when assign fails',
+    );
+    assert.ok(
+      script.includes('continue'),
+      'should skip to next iteration when assign fails',
+    );
+  });
+
+  it('still transitions to in_progress on successful assign', () => {
+    const script = buildOrchestratorWrapperScript('/usr/bin/claude', 'Task');
+    // in_progress transition should be inside the if block
+    assert.ok(
+      script.includes('"status":"in_progress"'),
+      'should still set in_progress on successful assign',
+    );
+  });
+});
+
 // ── Session name helpers ──────────────────────────────────────
 
 describe('Session name helpers', () => {

--- a/daemon/src/agents/tmux.ts
+++ b/daemon/src/agents/tmux.ts
@@ -241,13 +241,18 @@ if tasks:
       TASK_DESC=$(printf '%s' "$TASK_PARSED" | tail -n +3)
 
       if [ -n "$TASK_ID" ]; then
-        # Mark task as assigned, then in_progress
-        curl -s -o /dev/null -X PUT "http://localhost:$DAEMON_PORT/api/orchestrator/tasks/$TASK_ID" \\
+        # Transition pending → assigned → in_progress (both must succeed)
+        ASSIGN_OK=$(curl -s -w '%{http_code}' -o /dev/null -X PUT "http://localhost:$DAEMON_PORT/api/orchestrator/tasks/$TASK_ID" \\
           -H "Content-Type: application/json" \\
-          -d '{"status":"assigned","assignee":"orchestrator"}' || true
-        curl -s -o /dev/null -X PUT "http://localhost:$DAEMON_PORT/api/orchestrator/tasks/$TASK_ID" \\
-          -H "Content-Type: application/json" \\
-          -d '{"status":"in_progress"}' || true
+          -d '{"status":"assigned","assignee":"orchestrator"}')
+        if [ "$ASSIGN_OK" = "200" ]; then
+          curl -s -o /dev/null -X PUT "http://localhost:$DAEMON_PORT/api/orchestrator/tasks/$TASK_ID" \\
+            -H "Content-Type: application/json" \\
+            -d '{"status":"in_progress"}' || true
+        else
+          echo "WARN: Failed to assign task $TASK_ID (HTTP $ASSIGN_OK) — skipping" >&2
+          continue
+        fi
 
         # Build a prompt that includes the task ID so the orchestrator can update status
         TASK_PROMPT="You have a pending orchestrator task to work on.

--- a/daemon/src/api/task-queue.ts
+++ b/daemon/src/api/task-queue.ts
@@ -445,8 +445,45 @@ export async function handleTaskQueueRoute(
         ...values, taskId,
       );
 
+      // Fix 4: Auto-log activity on status change
+      if (updates.status) {
+        const activityMessage = updates.status === 'completed'
+          ? `Status → completed. Result: ${(updates.result as string)?.slice(0, 200) ?? '(none)'}`
+          : updates.status === 'failed'
+            ? `Status → failed. Error: ${(updates.error as string)?.slice(0, 200) ?? '(none)'}`
+            : `Status → ${updates.status}`;
+
+        exec(
+          `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+           VALUES (?, 'daemon', 'note', 'status_change', ?, ?)`,
+          taskId, activityMessage, ts,
+        );
+      }
+
       const updated = getTask(taskId)!;
       log.info('Task updated', { id: taskId, status: updated.status, assignee: updated.assignee });
+
+      // Fix 2: Auto-notify comms on task completion/failure
+      if (updates.status && TERMINAL_STATUSES.includes(updates.status as TaskStatus)) {
+        const msgBody = updates.status === 'completed'
+          ? `Task completed: ${updated.title}\n\nResult: ${updated.result ?? '(no result provided)'}`
+          : `Task failed: ${updated.title}\n\nError: ${updated.error ?? '(no error details)'}`;
+
+        try {
+          exec(
+            `INSERT INTO messages (from_agent, to_agent, type, body, created_at)
+             VALUES ('daemon', 'comms', 'result', ?, ?)`,
+            msgBody, new Date().toISOString(),
+          );
+          log.info('Auto-notified comms of task completion', { taskId, status: updates.status });
+        } catch (err) {
+          log.warn('Failed to auto-notify comms', { taskId, error: String(err) });
+        }
+
+        // Also inject directly into comms tmux session for immediate visibility
+        injectMessage('comms', `[task ${updates.status}] ${updated.title.slice(0, 100)}`);
+      }
+
       json(res, 200, withTimestamp(updated));
       return true;
     }

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -13,7 +13,7 @@
 
 import fs from 'node:fs';
 import { execFileSync } from 'node:child_process';
-import { query, update } from '../../core/db.js';
+import { query, exec, update } from '../../core/db.js';
 import { resolveProjectPath } from '../../core/config.js';
 import {
   isOrchestratorAlive as _isOrchestratorAlive,
@@ -129,6 +129,77 @@ function buildShutdownPrompt(reason: string): string {
 }
 
 /**
+ * Mark all in_progress and assigned tasks as failed when the orchestrator dies.
+ * Returns count of zombie tasks cleaned up.
+ */
+function cleanupZombieTasks(): number {
+  const ts = new Date().toISOString();
+  const zombies = query<{ id: string; status: string }>(
+    `SELECT id, status FROM orchestrator_tasks WHERE status IN ('in_progress', 'assigned')`,
+  );
+  for (const task of zombies) {
+    exec(
+      `UPDATE orchestrator_tasks SET status = 'failed', error = 'orchestrator_died', completed_at = ?, updated_at = ? WHERE id = ?`,
+      ts, ts, task.id,
+    );
+    // Auto-log activity for each zombie task
+    exec(
+      `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+       VALUES (?, 'daemon', 'note', 'cleanup', ?, ?)`,
+      task.id, `Task failed: orchestrator died while task was ${task.status}`, ts,
+    );
+  }
+  if (zombies.length > 0) {
+    log.warn('Cleaned up zombie tasks after orchestrator death', { count: zombies.length, taskIds: zombies.map(t => t.id) });
+  }
+  return zombies.length;
+}
+
+const PENDING_TIMEOUT_MS = 5 * 60 * 1000;   // 5 minutes
+const STALE_WORK_NOTES_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Warn about tasks that are stale in the queue or have no recent activity.
+ * Runs even when the orchestrator is dead — helps detect zombie tasks.
+ */
+function checkTaskTimeouts(): void {
+  const now = Date.now();
+
+  // Check pending/assigned tasks older than 5 minutes
+  const stalePending = query<{ id: string; title: string; status: string; created_at: string; assigned_at: string | null }>(
+    `SELECT id, title, status, created_at, assigned_at FROM orchestrator_tasks WHERE status IN ('pending', 'assigned')`,
+  );
+  for (const task of stalePending) {
+    const refTime = task.assigned_at ?? task.created_at;
+    const ageMs = now - new Date(refTime).getTime();
+    if (ageMs > PENDING_TIMEOUT_MS) {
+      log.warn('Task stale in queue', {
+        taskId: task.id,
+        title: task.title.slice(0, 80),
+        status: task.status,
+        ageMinutes: Math.round(ageMs / 60000),
+      });
+    }
+  }
+
+  // Check in_progress tasks with no recent work_notes updates
+  const activeTaskRows = query<{ id: string; title: string; updated_at: string; work_notes: string | null }>(
+    `SELECT id, title, updated_at, work_notes FROM orchestrator_tasks WHERE status = 'in_progress'`,
+  );
+  for (const task of activeTaskRows) {
+    const lastUpdate = new Date(task.updated_at).getTime();
+    if (now - lastUpdate > STALE_WORK_NOTES_MS) {
+      log.warn('In-progress task with no recent updates', {
+        taskId: task.id,
+        title: task.title.slice(0, 80),
+        lastUpdateMinutes: Math.round((now - lastUpdate) / 60000),
+        hasWorkNotes: !!task.work_notes,
+      });
+    }
+  }
+}
+
+/**
  * Read the orchestrator's context usage from its separate state file.
  */
 function getOrchestratorContextUsage(): number | null {
@@ -154,6 +225,10 @@ async function run(config: Record<string, unknown>): Promise<void> {
     log.warn('Session dir cleanup failed', { error: String(err) });
   }
 
+  // Check task timeouts on every tick — runs even when orchestrator is dead.
+  // This catches stale/zombie tasks from a dead orchestrator early.
+  checkTaskTimeouts();
+
   // If we previously nudged, check the outcome BEFORE the alive check.
   // The orchestrator may have exited gracefully in response to our nudge —
   // if we check alive first and reset nudge state, we'd never log the graceful exit.
@@ -166,6 +241,8 @@ async function run(config: Record<string, unknown>): Promise<void> {
         event_type: 'session_end',
         details: `Graceful exit after nudge: ${shutdownReason}`,
       });
+      // Clean up any tasks that were left in-progress or assigned
+      cleanupZombieTasks();
       shutdownNudgedAt = null;
       shutdownReason = null;
       return;
@@ -190,6 +267,8 @@ async function run(config: Record<string, unknown>): Promise<void> {
         event_type: 'session_end',
         details: `Force-killed: grace period expired (${shutdownReason})`,
       });
+      // Clean up any tasks that were left in-progress or assigned
+      cleanupZombieTasks();
       shutdownNudgedAt = null;
       shutdownReason = null;
       return;
@@ -199,8 +278,9 @@ async function run(config: Record<string, unknown>): Promise<void> {
     return;
   }
 
-  // Not alive and no pending nudge — nothing to do
+  // Not alive and no pending nudge — check for zombie tasks left behind
   if (!isOrchestratorAlive()) {
+    cleanupZombieTasks();
     return;
   }
 


### PR DESCRIPTION
## Summary

Recreated from a clean branch (v2) — previous PR #98 was contaminated with private instance files.

Five daemon-side fixes for orchestrator reliability:

1. **Zombie task cleanup**: When orchestrator dies, mark all in_progress and assigned tasks as failed with error `orchestrator_died`. Runs on every idle-monitor tick when orchestrator is dead.
2. **Daemon-side completion notification**: When a task reaches a terminal status (completed/failed), auto-send a message to comms and inject into the comms tmux session.
3. **Task timeout warnings**: Pending/assigned tasks >5min and in_progress tasks with no updates >10min now generate log warnings.
4. **Auto activity log**: Every task status change auto-logs an activity entry.
5. **Task queue polling fix**: Wrapper script now checks HTTP status codes when transitioning tasks. On failure, skips the task instead of running with a broken prompt.

Closes #95

## Files changed

- `daemon/src/automation/tasks/orchestrator-idle.ts` — zombie cleanup + timeout warnings
- `daemon/src/api/task-queue.ts` — completion notifications + auto activity log
- `daemon/src/agents/tmux.ts` — queue polling fix
- `daemon/src/__tests__/orchestrator-idle.test.ts` — new tests
- `daemon/src/__tests__/task-queue.test.ts` — new tests
- `daemon/src/__tests__/tmux.test.ts` — new tests

## Test plan

- [ ] `npm test` passes in daemon/
- [ ] Verify diff contains only the 6 files listed above (no private instance files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)