### PR TITLE
Fix context watchdog silent failure: add missing-file warnings (#94)

### DIFF
--- a/daemon/src/__tests__/context-watchdog.test.ts
+++ b/daemon/src/__tests__/context-watchdog.test.ts
@@ -1,0 +1,178 @@
+/**
+ * t-222: Context watchdog warns after consecutive missing state files
+ *
+ * Verifies that the context-watchdog emits a warn log after MISS_WARN_THRESHOLD
+ * consecutive misses (file not present), and resets the counter when the file
+ * is found successfully.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { _resetConfigForTesting, loadConfig } from '../core/config.js';
+import { initLogger, _resetLoggerForTesting } from '../core/logger.js';
+import { Scheduler } from '../automation/scheduler.js';
+import { register as registerContextWatchdog, _resetForTesting } from '../automation/tasks/context-watchdog.js';
+
+function makeTmpDir(): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kithkit-cw-'));
+  fs.writeFileSync(path.join(tmpDir, 'kithkit.config.yaml'), `
+agent:
+  name: test-agent
+scheduler:
+  tasks:
+    - name: context-watchdog
+      interval: "3m"
+      enabled: true
+      config:
+        requires_session: true
+`);
+  return tmpDir;
+}
+
+/** Read all warn entries from the daemon log in tmpDir. */
+function readWarnLogs(logDir: string): Array<{ msg: string; data?: Record<string, unknown> }> {
+  const logFile = path.join(logDir, 'daemon.log');
+  if (!fs.existsSync(logFile)) return [];
+  const lines = fs.readFileSync(logFile, 'utf8').trim().split('\n').filter(Boolean);
+  return lines
+    .map(l => { try { return JSON.parse(l); } catch { return null; } })
+    .filter((e): e is { level: string; msg: string; data?: Record<string, unknown> } => e !== null && e.level === 'warn');
+}
+
+describe('Context watchdog miss-count warnings (t-222)', () => {
+  let tmpDir: string;
+  let logDir: string;
+  let scheduler: Scheduler;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kithkit-cw-logs-'));
+    _resetConfigForTesting();
+    _resetForTesting();
+    // Initialize logger to capture warn output
+    initLogger({ logDir, minLevel: 'warn' });
+  });
+
+  afterEach(() => {
+    if (scheduler?.isRunning()) scheduler.stop();
+    _resetConfigForTesting();
+    _resetForTesting();
+    _resetLoggerForTesting({ logDir: os.tmpdir(), minLevel: 'info' });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(logDir, { recursive: true, force: true });
+  });
+
+  it('does not warn on the first or second consecutive miss', async () => {
+    const config = loadConfig(tmpDir);
+    scheduler = new Scheduler({
+      tasks: config.scheduler.tasks,
+      sessionExists: () => true,
+    });
+    registerContextWatchdog(scheduler);
+
+    // Run twice — below threshold (3)
+    await scheduler.triggerTask('context-watchdog');
+    await scheduler.triggerTask('context-watchdog');
+
+    const warns = readWarnLogs(logDir).filter(e =>
+      e.msg.includes('Context usage file missing for comms agent'),
+    );
+    assert.equal(warns.length, 0, 'Should not warn before threshold is reached');
+  });
+
+  it('emits exactly one warn at the third consecutive miss', async () => {
+    const config = loadConfig(tmpDir);
+    scheduler = new Scheduler({
+      tasks: config.scheduler.tasks,
+      sessionExists: () => true,
+    });
+    registerContextWatchdog(scheduler);
+
+    // Run 3 times — hits threshold on 3rd
+    await scheduler.triggerTask('context-watchdog');
+    await scheduler.triggerTask('context-watchdog');
+    await scheduler.triggerTask('context-watchdog');
+
+    const warns = readWarnLogs(logDir).filter(e =>
+      e.msg.includes('Context usage file missing for comms agent'),
+    );
+    assert.equal(warns.length, 1, 'Should emit exactly one warn at threshold');
+    assert.ok(
+      warns[0]!.msg.includes('scripts/context-monitor-statusline.sh'),
+      'Warn should mention the statusline script',
+    );
+  });
+
+  it('does not repeat the warn on 4th and subsequent misses', async () => {
+    const config = loadConfig(tmpDir);
+    scheduler = new Scheduler({
+      tasks: config.scheduler.tasks,
+      sessionExists: () => true,
+    });
+    registerContextWatchdog(scheduler);
+
+    // Run 5 times — warn fires only at 3rd
+    for (let i = 0; i < 5; i++) {
+      await scheduler.triggerTask('context-watchdog');
+    }
+
+    const warns = readWarnLogs(logDir).filter(e =>
+      e.msg.includes('Context usage file missing for comms agent'),
+    );
+    assert.equal(warns.length, 1, 'Should still emit only one warn after multiple misses');
+  });
+
+  it('resets miss counter after successful read and re-warns after threshold again', async () => {
+    const config = loadConfig(tmpDir);
+    scheduler = new Scheduler({
+      tasks: config.scheduler.tasks,
+      sessionExists: () => true,
+    });
+    registerContextWatchdog(scheduler);
+
+    // 3 misses → triggers warning
+    await scheduler.triggerTask('context-watchdog');
+    await scheduler.triggerTask('context-watchdog');
+    await scheduler.triggerTask('context-watchdog');
+
+    // Now create the state file → counter resets
+    const stateDir = path.join(tmpDir, '.claude', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'context-usage.json'),
+      JSON.stringify({ used_percentage: 10, remaining_percentage: 90, session_id: 'sess-1' }),
+    );
+
+    await scheduler.triggerTask('context-watchdog');
+
+    // Remove the file again → counter resets from 0
+    fs.unlinkSync(path.join(stateDir, 'context-usage.json'));
+
+    // 2 more misses — should NOT trigger a second warn (below new threshold)
+    await scheduler.triggerTask('context-watchdog');
+    await scheduler.triggerTask('context-watchdog');
+
+    const warns = readWarnLogs(logDir).filter(e =>
+      e.msg.includes('Context usage file missing for comms agent'),
+    );
+    assert.equal(warns.length, 1, 'Should only have 1 warn: counter was reset after successful read');
+  });
+
+  it('runs successfully on every trigger regardless of miss count', async () => {
+    const config = loadConfig(tmpDir);
+    scheduler = new Scheduler({
+      tasks: config.scheduler.tasks,
+      sessionExists: () => true,
+    });
+    registerContextWatchdog(scheduler);
+
+    // Run many times without state file — should never throw
+    for (let i = 0; i < 6; i++) {
+      const result = await scheduler.triggerTask('context-watchdog');
+      assert.equal(result.status, 'success', `Run ${i + 1} should succeed`);
+    }
+  });
+});

--- a/daemon/src/automation/tasks/context-watchdog.ts
+++ b/daemon/src/automation/tasks/context-watchdog.ts
@@ -20,6 +20,10 @@
  *
  * The watchdog reads context-usage.json (comms) and context-usage-orch.json
  * (orchestrator), both written by the statusline script on every turn.
+ *
+ * DEPENDENCY: Requires statusLine in .claude/settings.json to point to
+ * scripts/context-monitor-statusline.sh, which writes the JSON state files
+ * this watchdog reads. Without this, the watchdog silently no-ops.
  */
 
 import fs from 'node:fs';
@@ -77,6 +81,11 @@ let commsSessionId: string | null = null;
 let orchFiredTiers: Set<number> = new Set();
 let orchSessionId: string | null = null;
 
+// Track consecutive misses to warn about persistent missing state files
+let commsFileMissCount = 0;
+let orchFileMissCount = 0;
+const MISS_WARN_THRESHOLD = 3; // Warn after 3 consecutive misses (~9 minutes with 3m interval)
+
 interface ContextData {
   remaining_percentage?: number;
   used_percentage?: number;
@@ -110,7 +119,18 @@ function readContextFile(filePath: string): ContextData | null {
 function monitorComms(): void {
   const stateFile = resolveProjectPath('.claude', 'state', 'context-usage.json');
   const data = readContextFile(stateFile);
-  if (!data) return;
+  if (!data) {
+    commsFileMissCount++;
+    if (commsFileMissCount === MISS_WARN_THRESHOLD) {
+      log.warn(
+        'Context usage file missing for comms agent — watchdog cannot monitor context. ' +
+        'Ensure statusLine in .claude/settings.json points to scripts/context-monitor-statusline.sh',
+        { file: stateFile, consecutiveMisses: commsFileMissCount },
+      );
+    }
+    return;
+  }
+  commsFileMissCount = 0; // Reset on successful read
 
   const remaining = data.remaining_percentage ?? 100;
   const used = data.used_percentage ?? 0;
@@ -156,7 +176,18 @@ function monitorOrchestrator(): void {
 
   const stateFile = resolveProjectPath('.claude', 'state', 'context-usage-orch.json');
   const data = readContextFile(stateFile);
-  if (!data) return;
+  if (!data) {
+    orchFileMissCount++;
+    if (orchFileMissCount === MISS_WARN_THRESHOLD) {
+      log.warn(
+        'Context usage file missing for orchestrator — watchdog cannot monitor orchestrator context. ' +
+        'Ensure the orchestrator statusLine is configured correctly.',
+        { file: stateFile, consecutiveMisses: orchFileMissCount },
+      );
+    }
+    return;
+  }
+  orchFileMissCount = 0; // Reset on successful read
 
   const remaining = data.remaining_percentage ?? 100;
   const used = data.used_percentage ?? 0;
@@ -204,4 +235,17 @@ export function register(scheduler: Scheduler): void {
   scheduler.registerHandler('context-watchdog', async () => {
     await run();
   });
+}
+
+/**
+ * Reset module-level state for testing purposes.
+ * @internal
+ */
+export function _resetForTesting(): void {
+  commsFiredTiers = new Set();
+  commsSessionId = null;
+  orchFiredTiers = new Set();
+  orchSessionId = null;
+  commsFileMissCount = 0;
+  orchFileMissCount = 0;
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,6 +167,19 @@ scheduler:
       enabled: true
 ```
 
+**Context watchdog dependency**: The `context-watchdog` task reads JSON state files written by the statusline script on every Claude turn. For it to work, add this to `.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/context-monitor-statusline.sh"
+  }
+}
+```
+
+Without this, the watchdog silently no-ops — it has no context data to read. After 3 consecutive misses (~9 minutes), the daemon logs a warning to help diagnose the misconfiguration.
+
 Hot-reload the config without restarting the daemon:
 
 ```bash


### PR DESCRIPTION
## Summary

Recreated from a clean branch (v2) — previous PR #99 was contaminated with private instance files.

The context watchdog silently no-ops when `context-usage.json` is missing because the statusline script isn't wired up. This makes it impossible to tell the feature is broken without reading the source code.

Fixes:

1. **Consecutive-miss tracking**: After 3 missed reads (~9 minutes), log a warning with the expected file path and a hint to configure the statusLine in `.claude/settings.json`.
2. **Dependency note**: Document the statusline script requirement in the file header.
3. **Docs update**: Add context watchdog configuration instructions to `docs/getting-started.md`.
4. **Test isolation**: Add `_resetForTesting()` export.
5. **Tests**: New `context-watchdog.test.ts` covering miss-count thresholds, reset on successful read, and re-warning behavior.

Closes #94

## Files changed

- `daemon/src/automation/tasks/context-watchdog.ts` — miss tracking + warnings
- `daemon/src/__tests__/context-watchdog.test.ts` — new test file
- `docs/getting-started.md` — configuration docs

## Test plan

- [ ] `npm test` passes in daemon/
- [ ] Verify diff contains only the 3 files listed above (no private instance files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)