### PR TITLE
Fix #102: validate settings.json in session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -22,16 +22,16 @@ STATE_DIR="$PROJECT_DIR/.claude/state"
 SETTINGS_FILE="$PROJECT_DIR/.claude/settings.json"
 if [ -f "$SETTINGS_FILE" ]; then
   if ! python3 -c "import json, sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
-    echo "ERROR: .claude/settings.json contains invalid JSON."
-    echo ""
-    echo "  File: $SETTINGS_FILE"
-    echo ""
-    echo "  Common causes:"
-    echo "    - Merge conflict markers (<<<<<<, ======, >>>>>>) left by git stash/merge"
-    echo "    - Trailing commas or missing brackets"
-    echo "    - Manual edits that broke syntax"
-    echo ""
-    echo "  Fix the file and try again."
+    echo "ERROR: .claude/settings.json contains invalid JSON." >&2
+    echo "" >&2
+    echo "  File: $SETTINGS_FILE" >&2
+    echo "" >&2
+    echo "  Common causes:" >&2
+    echo "    - Merge conflict markers (<<<<<<<, =======, >>>>>>>) left by git stash/merge" >&2
+    echo "    - Trailing commas or missing brackets" >&2
+    echo "    - Manual edits that broke syntax" >&2
+    echo "" >&2
+    echo "  Fix the file and restart Claude." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

- Adds JSON validation of `.claude/settings.json` to `session-start.sh`, running before any other bootstrap logic
- If the file exists but contains invalid JSON (merge conflict markers, trailing commas, broken syntax), prints a clear error message with the file path and common causes, then exits non-zero
- All error output goes to **stderr** (`>&2`) so it does not pollute the context injection output on stdout
- Uses `python3 -c "import json, sys; json.load(open(sys.argv[1]))"` — zero dependencies, minimal overhead

## Changes

- Error messages redirected to stderr for proper stream separation
- Conflict marker examples corrected to full 7-char form (`<<<<<<<`, `=======`, `>>>>>>>`)
- "Fix the file and restart Claude" wording (clearer than "try again")

## Test plan

- [x] Valid `.claude/settings.json` passes silently (no output, exit 0)
- [x] Malformed JSON (merge conflict markers `<<<<<<<`) triggers error on stderr and exits 1
- [x] Stdout is empty when validation fails (error is stderr-only)
- [x] Missing `.claude/settings.json` is a no-op (check skipped, exit 0)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)