### PR TITLE
fix: escape angle brackets in orchestrator task prompt (#107)

### DIFF
--- a/daemon/src/agents/tmux.ts
+++ b/daemon/src/agents/tmux.ts
@@ -263,9 +263,9 @@ Title: $TASK_TITLE
 $TASK_DESC
 
 When you finish this task, update its status:
-  curl -s -X PUT http://localhost:$DAEMON_PORT/api/orchestrator/tasks/$TASK_ID -H 'Content-Type: application/json' -d '{\"status\":\"completed\",\"result\":\"<summary of what you did>\"}'
+  curl -s -X PUT http://localhost:$DAEMON_PORT/api/orchestrator/tasks/$TASK_ID -H 'Content-Type: application/json' -d '{\"status\":\"completed\",\"result\":\"{summary of what you did}\"}'
 If the task fails:
-  curl -s -X PUT http://localhost:$DAEMON_PORT/api/orchestrator/tasks/$TASK_ID -H 'Content-Type: application/json' -d '{\"status\":\"failed\",\"result\":\"<what went wrong>\"}'"
+  curl -s -X PUT http://localhost:$DAEMON_PORT/api/orchestrator/tasks/$TASK_ID -H 'Content-Type: application/json' -d '{\"status\":\"failed\",\"result\":\"{what went wrong}\"}'"
 
         printf '%s' "$TASK_PROMPT" > "$PROMPT_FILE"
         run_claude "$PROMPT_FILE"


### PR DESCRIPTION
## Summary
- Replace raw `<angle bracket>` placeholders in the orchestrator wrapper's pending-task prompt with `{curly brace}` delimiters
- Fixes Claude interpreting `<summary of what you did>` and `<what went wrong>` as XML tags
- Closes #107

## Changes
- `daemon/src/agents/tmux.ts`: Replace 2 angle-bracket placeholders in `TASK_PROMPT` template with curly-brace equivalents

## Test plan
- [x] `npm run build` passes (pre-existing error in `sdk-bridge.ts` unrelated to this change)
- [ ] Spawn orchestrator, verify pending-task prompt renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)