### PR TITLE
Fix A2A message type mismatch between agents

### DIFF
--- a/daemon/src/extensions/comms/agent-comms.ts
+++ b/daemon/src/extensions/comms/agent-comms.ts
@@ -23,7 +23,7 @@ const log = createLogger('agent-comms');
 
 export interface AgentMessage {
   from: string;
-  type: 'text' | 'status' | 'coordination' | 'pr-review';
+  type: string;
   text?: string;
   timestamp: string;
   messageId: string;
@@ -56,8 +56,6 @@ export interface CommsLogEntry {
   latencyMs?: number;
   error?: string;
 }
-
-const VALID_TYPES = ['text', 'status', 'coordination', 'pr-review'] as const;
 
 // ── State ─────────────────────────────────────────────────────
 
@@ -163,9 +161,6 @@ function validateMessage(body: unknown): { valid: boolean; error?: string } {
   }
   if (!msg.type || typeof msg.type !== 'string') {
     return { valid: false, error: "'type' is required and must be a string" };
-  }
-  if (!VALID_TYPES.includes(msg.type as typeof VALID_TYPES[number])) {
-    return { valid: false, error: `Invalid message type '${msg.type}'. Valid: ${VALID_TYPES.join(', ')}` };
   }
   if (!msg.messageId || typeof msg.messageId !== 'string') {
     return { valid: false, error: "'messageId' is required and must be a string" };
@@ -393,7 +388,7 @@ function resolveP2PName(
 
 export async function sendAgentMessage(
   peerName: string,
-  type: AgentMessage['type'],
+  type: string,
   text?: string,
   extra?: Partial<Pick<AgentMessage, 'status' | 'action' | 'task' | 'context' | 'callbackUrl' | 'repo' | 'branch' | 'pr'>>,
 ): Promise<AgentMessageResponse> {


### PR DESCRIPTION
## Summary
- Remove hardcoded `VALID_TYPES` allowlist (`text`, `status`, `coordination`, `pr-review`) from `agent-comms.ts` message validation
- Accept any non-empty string for the `type` field — only validate that required fields (`from`, `type`, `messageId`, `timestamp`) are present and are strings
- Widen `AgentMessage.type` from a union literal to `string` so agents can use custom type strings (`query`, `response`, `info`, etc.) without being rejected

## Root Cause
Each agent's `agent-comms.ts` validated incoming message types against a fixed allowlist. BMO uses `query`/`response`/`info`, while the default extension only accepted `text`/`status`/`coordination`/`pr-review`. Messages with unrecognized types were rejected with a 400 error, causing silent cross-agent communication failures.

## Test plan
- [ ] Send a message with `type: "query"` from BMO to R2 — should be accepted
- [ ] Send a message with `type: "text"` — still works (backward compatible)
- [ ] Send a message with empty `type: ""` — rejected (required field validation still enforced)
- [ ] Send a message with missing `type` — rejected
- [ ] Verify `formatMessage()` handles unknown types via its existing `default` switch case

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)