### PR TITLE
fix: rename cc4me-network to kithkit-a2a-client (#97)

### DIFF
--- a/daemon/src/extensions/comms/network/sdk-bridge.ts
+++ b/daemon/src/extensions/comms/network/sdk-bridge.ts
@@ -4,7 +4,7 @@
  * Initializes the A2ANetwork client, wires SDK events to session bridge,
  * and exposes the network client for agent-comms (P2P fallback).
  *
- * cc4me-network is loaded dynamically. If not installed, daemon degrades
+ * kithkit-a2a-client is loaded dynamically. If not installed, daemon degrades
  * gracefully to LAN-only mode.
  */
 
@@ -61,14 +61,14 @@ export async function initNetworkSDK(config: R2Config): Promise<boolean> {
   }
 
   try {
-    // Dynamic import — cc4me-network is optional
+    // Dynamic import — kithkit-a2a-client is optional
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let CC4MeNetworkClass: any;
     try {
-      const sdk = await import('cc4me-network');
-      CC4MeNetworkClass = sdk.CC4MeNetwork;
+      const sdk = await import('kithkit-a2a-client');
+      CC4MeNetworkClass = sdk.A2ANetwork;
     } catch {
-      log.warn('cc4me-network package not installed — P2P messaging unavailable. Install with: npm install cc4me-network');
+      log.warn('kithkit-a2a-client package not installed — P2P messaging unavailable. Install with: npm install kithkit-a2a-client');
       return false;
     }
 


### PR DESCRIPTION
## Summary
- Rename all references to the old `cc4me-network` package to `kithkit-a2a-client`
- Updates dynamic import, class name (`CC4MeNetwork` → `A2ANetwork`), and log/comment references
- Closes #97

## Changes
- `daemon/src/extensions/comms/network/sdk-bridge.ts`: 5 string replacements (2 comments, 1 import path, 1 class name, 1 warning message)

## Test plan
- [x] `npm run build` passes
- [ ] Daemon starts and A2A network initializes with new package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)