### PR TITLE
Fix #106: detect orphaned tasks from previous orchestrator instances

### DIFF
--- a/daemon/src/__tests__/orchestrator-idle.test.ts
+++ b/daemon/src/__tests__/orchestrator-idle.test.ts
@@ -242,6 +242,58 @@ describe('Orchestrator idle: zombie task cleanup', () => {
     assert.ok(activity[0]!.message.includes('orchestrator died'), `message: ${activity[0]!.message}`);
   });
 
+  it('marks tasks from a previous orchestrator as failed when new orchestrator is running', async () => {
+    // Insert an in_progress task with started_at BEFORE the orchestrator's started_at
+    // (simulating a task from a previous orchestrator instance)
+    const oldTime = new Date(Date.now() - 10 * 60_000).toISOString();
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, description, status, priority, started_at, created_at, updated_at)
+       VALUES ('orphan-task-1', 'Orphaned task', null, 'in_progress', 0, ?, ?, ?)`,
+      oldTime, oldTime, oldTime,
+    );
+
+    // Orchestrator is alive (new instance)
+    _setDepsForTesting({
+      isOrchestratorAlive: () => true,
+      killOrchestratorSession: () => false,
+      injectMessage: () => true,
+      cleanupSessionDirs: () => 0,
+    });
+
+    await _runForTesting({});
+
+    const tasks = query<{ id: string; status: string; error: string }>(
+      `SELECT id, status, error FROM orchestrator_tasks WHERE id = 'orphan-task-1'`,
+    );
+    assert.equal(tasks.length, 1);
+    assert.equal(tasks[0]!.status, 'failed', 'orphaned task should be marked failed');
+    assert.equal(tasks[0]!.error, 'orchestrator_restarted');
+  });
+
+  it('does not mark tasks from the current orchestrator as orphaned', async () => {
+    // Insert an in_progress task with started_at AFTER the orchestrator's started_at
+    const recentTime = new Date(Date.now() + 1000).toISOString();
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, description, status, priority, started_at, created_at, updated_at)
+       VALUES ('current-task-1', 'Current task', null, 'in_progress', 0, ?, ?, ?)`,
+      recentTime, recentTime, recentTime,
+    );
+
+    _setDepsForTesting({
+      isOrchestratorAlive: () => true,
+      killOrchestratorSession: () => false,
+      injectMessage: () => true,
+      cleanupSessionDirs: () => 0,
+    });
+
+    await _runForTesting({});
+
+    const tasks = query<{ id: string; status: string }>(
+      `SELECT id, status FROM orchestrator_tasks WHERE id = 'current-task-1'`,
+    );
+    assert.equal(tasks[0]!.status, 'in_progress', 'current task should NOT be marked as orphaned');
+  });
+
   it('does not touch completed or failed tasks during zombie cleanup', async () => {
     // Insert a completed task — should remain completed
     exec(

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -155,6 +155,58 @@ function cleanupZombieTasks(): number {
   return zombies.length;
 }
 
+/**
+ * Detect tasks orphaned by a previous orchestrator instance.
+ * When a new orchestrator spawns (e.g., via task escalation) while the old one's
+ * tasks are still in_progress/assigned, those tasks belong to the dead instance.
+ * We detect this by comparing task timestamps against the current orchestrator's started_at.
+ * Returns count of orphaned tasks cleaned up.
+ */
+function cleanupOrphanedTasks(): number {
+  // Get the current orchestrator's started_at
+  const orchRows = query<{ started_at: string | null }>(
+    "SELECT started_at FROM agents WHERE id = 'orchestrator'",
+  );
+  const orchStartedAt = orchRows[0]?.started_at;
+  if (!orchStartedAt) return 0;
+
+  const ts = new Date().toISOString();
+
+  // Find tasks that are in_progress or assigned but whose relevant timestamp
+  // predates the current orchestrator's started_at.
+  // For in_progress: use started_at (when it transitioned to in_progress), fall back to created_at.
+  // For assigned: use assigned_at, fall back to created_at.
+  const orphans = query<{ id: string; status: string }>(
+    `SELECT id, status FROM orchestrator_tasks
+     WHERE status IN ('in_progress', 'assigned')
+     AND (
+       (status = 'in_progress' AND COALESCE(started_at, created_at) < ?)
+       OR
+       (status = 'assigned' AND COALESCE(assigned_at, created_at) < ?)
+     )`,
+    orchStartedAt, orchStartedAt,
+  );
+
+  for (const task of orphans) {
+    exec(
+      `UPDATE orchestrator_tasks SET status = 'failed', error = 'orchestrator_restarted', completed_at = ?, updated_at = ? WHERE id = ?`,
+      ts, ts, task.id,
+    );
+    exec(
+      `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+       VALUES (?, 'daemon', 'note', 'cleanup', ?, ?)`,
+      task.id, `Task failed: orchestrator restarted while task was ${task.status}`, ts,
+    );
+  }
+  if (orphans.length > 0) {
+    log.info('Cleaned up orphaned tasks from previous orchestrator instance', {
+      count: orphans.length,
+      taskIds: orphans.map(t => t.id),
+    });
+  }
+  return orphans.length;
+}
+
 const PENDING_TIMEOUT_MS = 5 * 60 * 1000;   // 5 minutes
 const STALE_WORK_NOTES_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -228,6 +280,11 @@ async function run(config: Record<string, unknown>): Promise<void> {
   // Check task timeouts on every tick — runs even when orchestrator is dead.
   // This catches stale/zombie tasks from a dead orchestrator early.
   checkTaskTimeouts();
+
+  // Detect orphaned tasks from a previous orchestrator instance.
+  // Runs unconditionally — even when the orchestrator IS alive — because the new
+  // orchestrator's liveness masks the dead one's abandoned tasks.
+  cleanupOrphanedTasks();
 
   // If we previously nudged, check the outcome BEFORE the alive check.
   // The orchestrator may have exited gracefully in response to our nudge —


### PR DESCRIPTION
## Summary

- Fixes the zombie cleanup bug where `in_progress`/`assigned` tasks were never marked as `failed` when the orchestrator died and a new one spawned quickly
- Root cause: `cleanupZombieTasks()` only ran when `isOrchestratorAlive()` returned `false`, but a newly spawned orchestrator made it return `true`, masking the dead instance's abandoned tasks
- Adds `cleanupOrphanedTasks()` that runs unconditionally on every scheduler tick, comparing task timestamps against the current orchestrator's `started_at` to detect orphans from a previous instance
- Uses `log.info()` for visibility (existing cleanup logs were `debug`-level and invisible at default `info` log level)

## Changes

- `daemon/src/automation/tasks/orchestrator-idle.ts`: Added `cleanupOrphanedTasks()` function, called unconditionally in `run()` before nudge/alive checks
- `daemon/src/__tests__/orchestrator-idle.test.ts`: Added positive and negative tests for orphan detection

## Test plan

- [ ] TypeScript compilation passes (`tsc --noEmit`)
- [ ] Orphan detection correctly marks old tasks as `failed` with error `orchestrator_restarted`
- [ ] Current orchestrator's active tasks are NOT marked as orphaned
- [ ] Existing zombie cleanup (dead orchestrator path) still works

> **Note**: The test file has a pre-existing infrastructure issue on `main` where all tests fail with `SQLITE_CONSTRAINT_PRIMARYKEY` due to DB reset between test suites. This is a separate bug unrelated to this change — the new tests follow the exact same patterns as existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)