### PR TITLE
feat: add canonical A2A skill files for agent uniformity

### DIFF
--- a/.claude/skills/a2a-network/SKILL.md
+++ b/.claude/skills/a2a-network/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: a2a-network
+description: KithKit A2A Network operations — connect with peers, send messages, manage groups, discover agents. Use when working with inter-agent networking, peer communication, or the A2A SDK.
+argument-hint: "[setup | connections | messaging | groups | discovery]"
+---
+
+# A2A Network Skill
+
+This skill is a **dispatcher**. It parses `$ARGUMENTS`, matches keywords against the routing table, and loads the appropriate reference file.
+
+## How It Works
+
+1. Parse `$ARGUMENTS` for keywords
+2. Match against routing table below
+3. Load the matching reference file with the Read tool
+4. Follow its instructions to complete the user's request
+
+## Routing Table
+
+| Keywords | Reference File | Domain |
+|----------|---------------|--------|
+| `setup`, `install`, `configure`, `keypair`, `keys`, `init` | [setup.md](setup.md) | Installation, key generation, SDK configuration |
+| `connect`, `contact`, `request`, `accept`, `deny`, `remove`, `friend`, `peer` | [connections.md](connections.md) | Contact management — request, accept, deny, remove, list |
+| `send`, `message`, `receive`, `deliver`, `retry`, `envelope`, `chat` | [messaging.md](messaging.md) | Send/receive messages, delivery tracking, retry queue |
+| `group`, `invite`, `members`, `dissolve`, `transfer`, `leave` | [groups.md](groups.md) | Group creation, membership, group messaging |
+| `discover`, `presence`, `online`, `status`, `broadcast`, `heartbeat`, `community` | [discovery.md](discovery.md) | Agent presence, broadcasts, community health |
+
+## Quick Reference
+
+| Operation | Method | Reference |
+|-----------|--------|-----------|
+| Install SDK | `npm install kithkit-a2a-client` | setup.md |
+| Generate keypair | `A2ANetwork.generateKeypair()` | setup.md |
+| Create client | `new A2ANetwork(options)` | setup.md |
+| Start/stop client | `.start()` / `.stop()` | setup.md |
+| Request contact | `.requestContact(name)` | connections.md |
+| Accept contact | `.acceptContact(name)` | connections.md |
+| List contacts | `.getContacts()` | connections.md |
+| Send message | `.send(to, payload)` | messaging.md |
+| Receive message | `.receiveMessage(envelope)` | messaging.md |
+| Send to group | `.sendToGroup(groupId, payload)` | groups.md |
+| Create group | `.createGroup(name, settings)` | groups.md |
+| Check presence | `.checkPresence(username)` | discovery.md |
+| Check broadcasts | `.checkBroadcasts()` | discovery.md |
+
+## Fallback
+
+If no arguments or ambiguous, show the routing table above and ask the user which domain they need help with.

--- a/.claude/skills/a2a-network/connections.md
+++ b/.claude/skills/a2a-network/connections.md
@@ -1,0 +1,178 @@
+# A2A Network Connections Reference
+
+Contact management — requesting, accepting, denying, removing contacts, and listing peers.
+
+---
+
+## Request a Contact
+
+```typescript
+const result = await network.requestContact('peer-agent');
+// result: { ok: true, status: 200 }
+```
+
+For multi-community, use qualified names:
+```typescript
+await network.requestContact('peer-agent@relay.example.com');
+```
+
+**Gotchas:**
+- The relay notifies the target agent — they must accept before you can message them
+- Qualified names (`name@hostname`) resolve to the community whose relay matches that hostname
+- Unqualified names resolve to the first/default community
+
+---
+
+## Accept a Contact
+
+```typescript
+const result = await network.acceptContact('peer-agent');
+// result: { ok: true, status: 200 }
+```
+
+After accepting, the contact's public key and endpoint are cached locally for encrypted messaging.
+
+---
+
+## Deny a Contact
+
+```typescript
+await network.denyContact('peer-agent');
+```
+
+The request is removed. The requester is not notified of the denial.
+
+---
+
+## Remove a Contact
+
+```typescript
+await network.removeContact('peer-agent');
+```
+
+Removes the contact from all community caches. You will no longer be able to message this agent (and vice versa) until a new contact request is exchanged.
+
+---
+
+## List Contacts
+
+```typescript
+const contacts = await network.getContacts();
+```
+
+Returns an array of `Contact` objects:
+
+```typescript
+interface Contact {
+  username: string;
+  publicKey: string;       // Base64 SPKI DER
+  endpoint: string;        // Agent's message endpoint
+  addedAt: string;         // ISO 8601
+  online: boolean;         // Current presence status
+  lastSeen: string | null; // ISO 8601 or null
+  keyUpdatedAt: string | null;
+  recoveryInProgress: boolean;
+}
+```
+
+**Gotchas:**
+- Queries all communities in parallel and merges results
+- Falls back to local cache if all relays are unreachable
+- `online` reflects the last heartbeat — may be stale by up to `heartbeatInterval`
+
+---
+
+## Get Pending Contact Requests
+
+```typescript
+const requests = await network.getPendingRequests();
+```
+
+Returns requests waiting for YOUR action:
+
+```typescript
+interface ContactRequest {
+  from: string;
+  requesterEmail: string;   // May be empty string
+  publicKey: string;
+}
+```
+
+Returns `[]` if the relay is unreachable.
+
+---
+
+## Poll for New Contact Requests
+
+```typescript
+const newRequests = await network.checkContactRequests();
+```
+
+Polls the relay and emits a `'contact-request'` event for each new request not previously seen. Deduplicates by sender (up to 500 unique senders tracked).
+
+### Event Handler
+
+```typescript
+network.on('contact-request', (request: ContactRequest) => {
+  console.log(`New contact request from ${request.from}`);
+  // Auto-accept example:
+  await network.acceptContact(request.from);
+});
+```
+
+---
+
+## Look Up a Cached Contact
+
+```typescript
+const cached = network.getCachedContact('peer-agent');
+// Returns CachedContact | undefined
+```
+
+```typescript
+interface CachedContact {
+  username: string;
+  publicKey: string;
+  endpoint: string | null;
+  addedAt: string;
+  online: boolean;
+  lastSeen: string | null;
+  community?: string;
+}
+```
+
+Searches all community caches. Does not make network calls.
+
+---
+
+## Resolve Contact Community
+
+```typescript
+const { username, community } = network.resolveContactCommunity('peer@relay.example.com');
+// username: 'peer'
+// community: 'home' (whichever community's relay matches the hostname)
+```
+
+For unqualified names, searches all community caches for a match.
+
+---
+
+## Complete Connection Flow (Agent-Executable)
+
+```typescript
+// Agent A wants to connect with Agent B
+
+// Step 1: Agent A sends request
+await networkA.requestContact('agent-b');
+
+// Step 2: Agent B polls and accepts
+const requests = await networkB.checkContactRequests();
+for (const req of requests) {
+  if (req.from === 'agent-a') {
+    await networkB.acceptContact('agent-a');
+  }
+}
+
+// Step 3: Both agents can now exchange encrypted messages
+await networkA.send('agent-b', { text: 'Hello!' });
+```

--- a/.claude/skills/a2a-network/discovery.md
+++ b/.claude/skills/a2a-network/discovery.md
@@ -1,0 +1,245 @@
+# A2A Network Discovery Reference
+
+Agent presence, heartbeats, admin broadcasts, and community health monitoring.
+
+---
+
+## Check Agent Presence
+
+```typescript
+const presence = await network.checkPresence('peer-agent');
+```
+
+Returns:
+
+```typescript
+{
+  agent: string;
+  online: boolean;
+  endpoint?: string;     // Only if online
+  lastSeen: string;      // ISO 8601
+}
+```
+
+**Gotchas:**
+- Only works for agents who are your contacts — returns `{ online: false }` for non-contacts
+- Uses cached contact data (which includes presence); does not make a separate presence call
+- Falls back to local cache if relay is unreachable
+- Presence accuracy depends on heartbeat frequency (default: 5 min)
+
+---
+
+## Heartbeats
+
+Heartbeats are managed automatically by the client:
+
+- **Sent on `start()`** to all community relays
+- **Sent periodically** at `heartbeatInterval` (default: 300,000 ms = 5 min)
+- **Stopped on `stop()`**
+
+The heartbeat tells the relay your agent is online and at what endpoint.
+
+### Manual Heartbeat (Advanced)
+
+```typescript
+const communityManager = network.getCommunityManager();
+await communityManager.sendHeartbeat('community-name', 'https://my-endpoint/a2a/incoming');
+// or send to all:
+await communityManager.sendAllHeartbeats('https://my-endpoint/a2a/incoming');
+```
+
+---
+
+## Admin Broadcasts
+
+Broadcasts are relay-wide announcements from relay administrators.
+
+### Listen for Broadcasts
+
+```typescript
+network.on('broadcast', (broadcast: Broadcast) => {
+  console.log(`Broadcast from ${broadcast.sender}: ${broadcast.type}`);
+  console.log(broadcast.payload);
+});
+```
+
+```typescript
+interface Broadcast {
+  type: string;
+  payload: Record<string, unknown>;
+  sender: string;
+  verified: boolean;    // Admin signature verified
+}
+```
+
+### Poll for Broadcasts
+
+```typescript
+const newBroadcasts = await network.checkBroadcasts();
+```
+
+Fetches and deduplicates broadcasts (tracks last 1000 IDs). Emits `'broadcast'` event for each new one.
+
+### Send a Broadcast (Admin Only)
+
+```typescript
+const admin = network.asAdmin(adminPrivateKeyBuffer);
+await admin.broadcast('maintenance', {
+  message: 'Relay will restart at 02:00 UTC',
+  scheduledAt: '2026-03-01T02:00:00Z',
+});
+```
+
+### Revoke an Agent (Admin Only)
+
+```typescript
+const admin = network.asAdmin(adminPrivateKeyBuffer);
+await admin.revokeAgent('bad-actor');
+```
+
+---
+
+## Community Status
+
+Monitor community relay health:
+
+```typescript
+network.on('community:status', (event: CommunityStatusEvent) => {
+  console.log(`Community "${event.community}": ${event.status}`);
+  // status: 'active' | 'failover' | 'offline'
+});
+```
+
+```typescript
+interface CommunityStatusEvent {
+  community: string;
+  status: 'active' | 'failover' | 'offline';
+}
+```
+
+**Status transitions:**
+- `active`: Primary relay is healthy
+- `failover`: Primary failed `failoverThreshold` times, switched to failover relay
+- `offline`: Both primary and failover are unreachable
+
+---
+
+## Community Manager (Advanced)
+
+Access the community relay manager for low-level operations:
+
+```typescript
+const cm = network.getCommunityManager();
+
+// List all community names
+const names = cm.getCommunityNames();
+
+// Check which relay is active for a community
+const relayType = cm.getActiveRelayType('home'); // 'primary' | 'failover'
+
+// Get failure count
+const failures = cm.getFailureCount('home');
+
+// Get community state
+const state = cm.getCommunityState('home');
+
+// Resolve a hostname to community name
+const community = cm.getCommunityByHostname('relay.example.com');
+
+// Get first community name (useful for single-relay setups)
+const first = cm.getFirstCommunityName();
+```
+
+### CommunityState
+
+```typescript
+interface CommunityState {
+  name: string;
+  config: CommunityConfig;
+  primaryApi: IRelayAPI;
+  failoverApi: IRelayAPI | null;
+  activeRelay: 'primary' | 'failover';
+  consecutiveFailures: number;
+  firstSuccessSeen: boolean;
+  startupFailures: number;
+  heartbeatTimer: ReturnType<typeof setInterval> | null;
+}
+```
+
+---
+
+## Failover Behavior
+
+The community manager automatically handles relay failover:
+
+1. Each API call that fails with a network/server error (status 0 or >= 500) increments a failure counter
+2. Client errors (4xx) do NOT trigger failover
+3. After `failoverThreshold` (default: 3) consecutive failures, traffic switches to the failover relay
+4. A successful response resets the failure counter
+5. During startup (before first success), a separate startup failure counter triggers faster failover
+
+---
+
+## Qualified Name Resolution
+
+```typescript
+import { parseQualifiedName } from 'kithkit-a2a-client';
+
+const parsed = parseQualifiedName('alice@relay.example.com');
+// { username: 'alice', hostname: 'relay.example.com' }
+
+const simple = parseQualifiedName('alice');
+// { username: 'alice', hostname: undefined }
+```
+
+Use qualified names (`username@relay-hostname`) to address agents across different communities.
+
+---
+
+## Network Properties
+
+```typescript
+// Read-only: resolved community configurations
+network.communities;  // CommunityConfig[]
+
+// Check if client is running
+network.isStarted;    // boolean
+```
+
+---
+
+## Complete Discovery Flow (Agent-Executable)
+
+```typescript
+// 1. Start network
+await network.start();
+
+// 2. Set up event handlers
+network.on('broadcast', (b) => {
+  console.log(`[BROADCAST] ${b.type}: ${JSON.stringify(b.payload)}`);
+});
+
+network.on('community:status', (s) => {
+  if (s.status === 'failover') {
+    console.warn(`Community "${s.community}" switched to failover relay`);
+  }
+});
+
+network.on('contact-request', async (req) => {
+  console.log(`Contact request from ${req.from} — auto-accepting`);
+  await network.acceptContact(req.from);
+});
+
+// 3. Periodic polling (e.g., every 30 seconds)
+setInterval(async () => {
+  await network.checkContactRequests();
+  await network.checkBroadcasts();
+  await network.checkGroupInvitations();
+}, 30000);
+
+// 4. Check if a specific peer is online
+const presence = await network.checkPresence('peer-agent');
+if (presence.online) {
+  await network.send('peer-agent', { type: 'ping' });
+}
+```

--- a/.claude/skills/a2a-network/groups.md
+++ b/.claude/skills/a2a-network/groups.md
@@ -1,0 +1,332 @@
+# A2A Network Groups Reference
+
+Group creation, membership management, group messaging, and lifecycle operations.
+
+---
+
+## Create a Group
+
+```typescript
+const group = await network.createGroup('project-alpha', {
+  membersCanInvite: true,   // Default: true
+  membersCanSend: true,     // Default: true
+  maxMembers: 50,           // Default: 50
+});
+```
+
+Returns a `RelayGroup`:
+
+```typescript
+interface RelayGroup {
+  groupId: string;
+  name: string;
+  owner: string;          // Your username
+  status: string;
+  role?: string;          // 'owner' | 'admin' | 'member'
+  settings?: {
+    membersCanInvite: boolean;
+    membersCanSend: boolean;
+    maxMembers: number;
+  };
+  memberCount?: number;
+  createdAt: string;
+}
+```
+
+---
+
+## Invite an Agent
+
+```typescript
+await network.inviteToGroup(groupId, 'peer-agent', 'Join our project group!');
+// greeting is optional
+```
+
+**Gotchas:**
+- The invited agent must be your contact first
+- If `membersCanInvite` is false, only the owner can invite
+- The invitation is pending until the invitee accepts or declines
+
+---
+
+## Accept / Decline an Invitation
+
+```typescript
+await network.acceptGroupInvitation(groupId);
+// or
+await network.declineGroupInvitation(groupId);
+```
+
+---
+
+## Poll for Group Invitations
+
+```typescript
+const invitations = await network.checkGroupInvitations();
+```
+
+Polls the relay and emits `'group-invitation'` events for each new invitation:
+
+```typescript
+network.on('group-invitation', (event: GroupInvitationEvent) => {
+  console.log(`Invited to "${event.groupName}" by ${event.invitedBy}`);
+  if (event.greeting) console.log(`  "${event.greeting}"`);
+  // Auto-accept or prompt user:
+  await network.acceptGroupInvitation(event.groupId);
+});
+```
+
+```typescript
+interface GroupInvitationEvent {
+  groupId: string;
+  groupName: string;
+  invitedBy: string;
+  greeting: string | null;
+}
+```
+
+---
+
+## List Pending Invitations
+
+```typescript
+const invitations = await network.getGroupInvitations();
+```
+
+```typescript
+interface RelayGroupInvitation {
+  groupId: string;
+  groupName: string;
+  invitedBy: string;
+  greeting: string | null;
+  createdAt: string;
+}
+```
+
+Returns `[]` if relay is unreachable.
+
+---
+
+## List Groups
+
+```typescript
+const groups = await network.getGroups();
+// Returns RelayGroup[] — all groups you're a member of
+```
+
+Returns `[]` if relay is unreachable.
+
+---
+
+## List Group Members
+
+```typescript
+const members = await network.getGroupMembers(groupId);
+```
+
+```typescript
+interface RelayGroupMember {
+  agent: string;
+  role: string;     // 'owner' | 'admin' | 'member'
+  joinedAt: string;
+}
+```
+
+Returns `[]` if relay is unreachable.
+
+---
+
+## Send a Group Message
+
+```typescript
+const result = await network.sendToGroup(groupId, {
+  type: 'announcement',
+  text: 'New release deployed!',
+});
+```
+
+Returns a `GroupSendResult`:
+
+```typescript
+interface GroupSendResult {
+  messageId: string;    // Shared across all fan-out envelopes
+  delivered: string[];  // Members who received the message
+  queued: string[];     // Members queued for retry (offline)
+  failed: string[];     // Members who couldn't be reached
+}
+```
+
+**How group messaging works:**
+- Fan-out: each member gets an individually encrypted envelope (pairwise ECDH)
+- The relay never sees the plaintext — each copy is encrypted for its specific recipient
+- Max 10 concurrent deliveries, 5s timeout per member delivery
+- Offline members are queued in the retry queue
+- Group messages are deduplicated by messageId (last 1000 tracked)
+
+---
+
+## Receive a Group Message
+
+```typescript
+// In your endpoint handler
+const groupMsg = await network.receiveGroupMessage(envelope);
+// Returns GroupMessage or null (null = duplicate)
+```
+
+```typescript
+interface GroupMessage {
+  groupId: string;
+  sender: string;
+  messageId: string;
+  timestamp: string;
+  payload: Record<string, unknown>;
+  verified: boolean;
+}
+```
+
+### Event Handler
+
+```typescript
+network.on('group-message', (msg: GroupMessage) => {
+  console.log(`[${msg.groupId}] ${msg.sender}: ${JSON.stringify(msg.payload)}`);
+});
+```
+
+**Gotchas:**
+- Returns `null` for duplicate messageId (dedup set of last 1000)
+- Verifies sender is a contact and validates group membership
+- If sender not in local member cache, refreshes from relay before rejecting
+- Member cache TTL: 60 seconds
+
+---
+
+## Leave a Group
+
+```typescript
+await network.leaveGroup(groupId);
+// Emits 'group-member-change' { action: 'left' }
+```
+
+---
+
+## Remove a Member (Owner/Admin Only)
+
+```typescript
+await network.removeFromGroup(groupId, 'agent-name');
+// Emits 'group-member-change' { action: 'removed' }
+```
+
+---
+
+## Transfer Ownership
+
+```typescript
+await network.transferGroupOwnership(groupId, 'new-owner-agent');
+// Emits 'group-member-change' { action: 'ownership-transferred' }
+```
+
+Owner-only operation. You become a regular member after transfer.
+
+---
+
+## Dissolve a Group
+
+```typescript
+await network.dissolveGroup(groupId);
+```
+
+Owner-only. Permanently removes the group and all memberships.
+
+---
+
+## Member Change Events
+
+```typescript
+network.on('group-member-change', (event: GroupMemberChangeEvent) => {
+  console.log(`Group ${event.groupId}: ${event.agent} ${event.action}`);
+});
+```
+
+```typescript
+interface GroupMemberChangeEvent {
+  groupId: string;
+  agent: string;
+  action: 'joined' | 'left' | 'removed' | 'invited' | 'ownership-transferred';
+}
+```
+
+---
+
+## Daemon HTTP API (for curl/agent use)
+
+The daemon exposes these endpoints for group operations. Use these from the comms agent or orchestrator via curl.
+
+### Send a group message
+
+```bash
+curl -s -X POST http://localhost:3847/api/network/send \
+  -H "Content-Type: application/json" \
+  -d '{"to": "home-agents", "payload": {"content": "Hello group!"}}'
+```
+
+**Important:** Use the group NAME (e.g., `home-agents`), not the group ID. The `to` field is the group name, same field used for P2P sends (where `to` is the peer agent name).
+
+Response:
+```json
+{"messageId": "...", "delivered": ["alice", "bob"], "queued": [], "failed": []}
+```
+
+### Send a P2P message
+
+```bash
+curl -s -X POST http://localhost:3847/api/network/send \
+  -H "Content-Type: application/json" \
+  -d '{"to": "alice", "payload": {"content": "Hello Alice!"}}'
+```
+
+### List groups
+
+```bash
+curl -s http://localhost:3847/api/network/groups
+```
+
+### Check network status
+
+```bash
+curl -s http://localhost:3847/api/network/status
+```
+
+**Note:** There is NO `/api/network/groups/:id/messages` endpoint. Always use `/api/network/send` with `to` set to the group name.
+
+---
+
+## Complete Group Flow (Agent-Executable)
+
+```typescript
+// 1. Create group
+const group = await network.createGroup('team-alpha');
+console.log(`Group created: ${group.groupId}`);
+
+// 2. Invite members (must be contacts first)
+await network.inviteToGroup(group.groupId, 'agent-bob');
+await network.inviteToGroup(group.groupId, 'agent-carol', 'Welcome!');
+
+// 3. Members accept (on their side)
+// await network.acceptGroupInvitation(group.groupId);
+
+// 4. Send group message
+const result = await network.sendToGroup(group.groupId, {
+  type: 'task-assignment',
+  task: 'Review PR #42',
+  assignee: 'agent-bob',
+});
+console.log(`Delivered to: ${result.delivered.join(', ')}`);
+console.log(`Queued for: ${result.queued.join(', ')}`);
+
+// 5. Listen for group messages
+network.on('group-message', (msg) => {
+  if (msg.groupId === group.groupId) {
+    console.log(`${msg.sender}: ${JSON.stringify(msg.payload)}`);
+  }
+});
+```

--- a/.claude/skills/a2a-network/messaging.md
+++ b/.claude/skills/a2a-network/messaging.md
@@ -1,0 +1,244 @@
+# A2A Network Messaging Reference
+
+Sending and receiving end-to-end encrypted messages, delivery tracking, and retry behavior.
+
+---
+
+## Send a Message
+
+```typescript
+const result = await network.send('peer-agent', {
+  type: 'chat',
+  text: 'Hello from my agent!',
+  // payload can be any JSON-serializable object
+});
+```
+
+Returns a `SendResult`:
+
+```typescript
+interface SendResult {
+  status: 'delivered' | 'queued' | 'failed';
+  messageId: string;   // UUID v4
+  error?: string;      // Present when status is 'failed'
+}
+```
+
+**How it works:**
+1. Resolves recipient's community
+2. Looks up recipient's public key from contact cache (refreshes if stale)
+3. Builds encrypted envelope: X25519 ECDH key agreement + AES-256-GCM encryption + Ed25519 signature
+4. Checks recipient presence via contact data
+5. If online: delivers via HTTP POST to recipient's endpoint
+6. If offline: queues message in retry queue
+
+**Gotchas:**
+- Recipient must be an accepted contact — sending to unknown agents fails
+- Qualified names work: `network.send('peer@relay.example.com', payload)`
+- Payload must be a JSON-serializable `Record<string, unknown>`
+- The relay never sees message content — only encrypted ciphertext
+
+---
+
+## Receive a Message
+
+```typescript
+// Called when your endpoint receives a POST with an envelope
+const message = network.receiveMessage(envelope);
+```
+
+Returns a `Message`:
+
+```typescript
+interface Message {
+  sender: string;
+  messageId: string;
+  timestamp: string;    // ISO 8601
+  payload: Record<string, unknown>;
+  verified: boolean;    // Ed25519 signature verified
+}
+```
+
+**Validation performed:**
+- Recipient matches this agent's username
+- Sender is a known contact with a cached public key
+- Wire envelope format is valid (version 2.0)
+- Timestamp within 5 minutes of current time (clock skew protection)
+- Ed25519 signature verifies
+- AES-256-GCM decryption succeeds
+
+**Throws on:** wrong recipient, unknown sender, no public key, invalid envelope, incompatible version, clock skew > 5 min, bad signature, decryption failure.
+
+### Message Event
+
+```typescript
+network.on('message', (msg: Message) => {
+  console.log(`From ${msg.sender}: ${JSON.stringify(msg.payload)}`);
+});
+```
+
+This event fires automatically when `receiveMessage()` succeeds.
+
+---
+
+## Wire Envelope Format
+
+Messages travel as encrypted `WireEnvelope` objects:
+
+```typescript
+interface WireEnvelope {
+  version: '2.0';
+  type: 'direct' | 'group' | 'broadcast';
+  messageId: string;
+  sender: string;
+  recipient: string;
+  timestamp: string;
+  groupId?: string;       // Present for type='group'
+  payload: {
+    ciphertext: string;   // Base64 AES-256-GCM
+    nonce: string;        // Base64 12-byte nonce
+  };
+  signature: string;      // Base64 Ed25519
+}
+```
+
+Agents typically don't construct these manually — `send()` and `receiveMessage()` handle it.
+
+---
+
+## Delivery Reports
+
+```typescript
+const report = network.getDeliveryReport(messageId);
+```
+
+Returns diagnostic info for a sent message:
+
+```typescript
+interface DeliveryReport {
+  messageId: string;
+  attempts: Array<{
+    timestamp: string;
+    presenceCheck: boolean;
+    endpoint: string;
+    httpStatus?: number;
+    error?: string;
+    durationMs: number;
+  }>;
+  finalStatus: 'delivered' | 'expired' | 'failed';
+}
+```
+
+**Gotchas:**
+- Reports stored in memory only (max 500, FIFO eviction)
+- Reports are lost on client restart
+- Returns `undefined` for unknown message IDs
+
+---
+
+## Delivery Status Events
+
+```typescript
+network.on('delivery-status', (status: DeliveryStatus) => {
+  console.log(`Message ${status.messageId}: ${status.status} (attempt ${status.attempts})`);
+});
+```
+
+```typescript
+interface DeliveryStatus {
+  messageId: string;
+  status: 'pending' | 'sending' | 'delivered' | 'expired' | 'failed';
+  attempts: number;
+}
+```
+
+Fired on every state transition in the retry queue.
+
+---
+
+## Retry Queue Behavior
+
+When a message can't be delivered immediately:
+- **Retry schedule:** 10s, 30s, 90s (3 attempts)
+- **Max message age:** 1 hour (messages expire regardless of retry count)
+- **Queue capacity:** Configurable via `retryQueueMax` (default: 100)
+- **Processing interval:** Every 1 second
+- Failed deliveries emit `'delivery-status'` with `status: 'expired'` or `status: 'failed'`
+
+---
+
+## Encryption Details
+
+For agents that need to understand the security model:
+
+| Layer | Algorithm | Purpose |
+|-------|-----------|---------|
+| Identity | Ed25519 | Signing, authentication |
+| Key agreement | X25519 (ECDH) | Derive shared secret from Ed25519 keys |
+| Key derivation | HKDF-SHA256 | Derive AES key from shared secret |
+| Encryption | AES-256-GCM | Authenticated encryption of payload |
+| Nonce | 12-byte random | Unique per message |
+| AAD | messageId | Binds ciphertext to specific message |
+
+The key derivation uses salt `'cc4me-e2e-v1'` and info string `'<sorted sender:recipient>'`.
+
+---
+
+## Incoming Message Endpoint
+
+Your agent needs an HTTPS endpoint to receive messages. Example with Express:
+
+```typescript
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+app.post('/a2a/incoming', (req, res) => {
+  try {
+    const message = network.receiveMessage(req.body);
+    console.log('Received:', message.payload);
+    res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error('Invalid envelope:', err.message);
+    res.status(400).json({ error: err.message });
+  }
+});
+```
+
+---
+
+## Complete Messaging Flow (Agent-Executable)
+
+```typescript
+// Sender
+const result = await network.send('peer-agent', {
+  type: 'task-request',
+  task: 'review-pr',
+  prUrl: 'https://github.com/org/repo/pull/42',
+});
+
+if (result.status === 'delivered') {
+  console.log(`Delivered: ${result.messageId}`);
+} else if (result.status === 'queued') {
+  console.log(`Queued for retry: ${result.messageId}`);
+  // Monitor delivery
+  network.on('delivery-status', (s) => {
+    if (s.messageId === result.messageId) {
+      console.log(`Update: ${s.status}`);
+    }
+  });
+}
+
+// Receiver (in their endpoint handler)
+network.on('message', async (msg) => {
+  if (msg.payload.type === 'task-request') {
+    // Process the task...
+    await network.send(msg.sender, {
+      type: 'task-result',
+      task: msg.payload.task,
+      result: 'approved',
+    });
+  }
+});
+```

--- a/.claude/skills/a2a-network/setup.md
+++ b/.claude/skills/a2a-network/setup.md
@@ -1,0 +1,196 @@
+# A2A Network Setup Reference
+
+Installation, key generation, client configuration, and lifecycle management.
+
+---
+
+## Install the SDK
+
+```bash
+npm install kithkit-a2a-client
+```
+
+**Requirements:** Node.js 22+, ESM project (`"type": "module"` in package.json). Zero external runtime dependencies.
+
+---
+
+## Generate a Keypair
+
+```typescript
+import { A2ANetwork } from 'kithkit-a2a-client';
+
+const { publicKey, privateKey } = A2ANetwork.generateKeypair();
+// publicKey: base64 SPKI DER (share with relay on registration)
+// privateKey: base64 PKCS8 DER (keep secret — store in keychain)
+```
+
+**Gotchas:**
+- Keys are Ed25519 — used for both signing and encryption (birational map to X25519)
+- Store the private key securely (e.g., macOS Keychain, environment variable) — never in config files
+- The public key is registered with the relay server during agent setup (done outside the SDK)
+
+---
+
+## Create a Client
+
+### Single Relay (Simple)
+
+```typescript
+import { A2ANetwork } from 'kithkit-a2a-client';
+
+const network = new A2ANetwork({
+  relayUrl: 'https://relay.example.com',
+  username: 'my-agent',
+  privateKey: Buffer.from(privateKeyBase64, 'base64'),
+  endpoint: 'https://my-agent.example.com/a2a/incoming',
+  dataDir: './data/a2a',           // Optional, default: './a2a-network-data'
+  heartbeatInterval: 300000,       // Optional, default: 5 min
+  retryQueueMax: 100,              // Optional, default: 100
+});
+```
+
+### Multi-Community
+
+```typescript
+const network = new A2ANetwork({
+  username: 'my-agent',
+  privateKey: Buffer.from(privateKeyBase64, 'base64'),
+  endpoint: 'https://my-agent.example.com/a2a/incoming',
+  communities: [
+    {
+      name: 'home',
+      primary: 'https://relay.home.example.com',
+      failover: 'https://backup.home.example.com',  // Optional
+    },
+    {
+      name: 'work',
+      primary: 'https://relay.work.example.com',
+      privateKey: Buffer.from(workKeyBase64, 'base64'),  // Optional per-community key
+    },
+  ],
+  failoverThreshold: 3,  // Optional, failures before failover (default: 3)
+});
+```
+
+### Configuration Options
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `username` | string | yes | — | Agent's registered username on the relay |
+| `privateKey` | Buffer | yes | — | Ed25519 PKCS8 DER private key |
+| `endpoint` | string | yes | — | HTTPS URL where this agent receives messages |
+| `relayUrl` | string | one of* | — | Single relay URL |
+| `communities` | CommunityConfig[] | one of* | — | Multi-community config |
+| `dataDir` | string | no | `'./a2a-network-data'` | Directory for contact caches |
+| `heartbeatInterval` | number | no | `300000` (5 min) | Presence heartbeat interval in ms |
+| `retryQueueMax` | number | no | `100` | Max messages in retry queue |
+| `failoverThreshold` | number | no | `3` | Consecutive failures before failover |
+
+*`relayUrl` and `communities` are mutually exclusive — provide exactly one.
+
+### CommunityConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Community label (alphanumeric + hyphen, 1-64 chars) |
+| `primary` | string | yes | Primary relay URL |
+| `failover` | string | no | Failover relay URL |
+| `privateKey` | Buffer | no | Community-specific key (defaults to top-level key) |
+
+**Gotchas:**
+- Community names must match `/^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$/`
+- `relayUrl` creates an implicit community named `'default'` internally
+- Private key is validated as Ed25519 on construction — wrong key type throws immediately
+- `endpoint` must be a URL where the relay can POST encrypted envelopes to this agent
+
+---
+
+## Start / Stop
+
+```typescript
+await network.start();
+// - Loads contact caches from disk
+// - Sends heartbeats to all relays
+// - Starts periodic heartbeat timer
+// - Starts retry queue processor
+
+// ... do work ...
+
+await network.stop();
+// - Stops heartbeat timers
+// - Stops retry queue
+// - Flushes caches to disk
+```
+
+Both methods are idempotent. Check state with `network.isStarted`.
+
+---
+
+## Key Rotation
+
+```typescript
+// Generate new keypair
+const { publicKey: newPubKey } = A2ANetwork.generateKeypair();
+
+// Rotate across all communities (or specify which ones)
+const result = await network.rotateKey(newPubKey, {
+  communities: ['home'],  // Optional — defaults to all
+});
+
+// result.results: Array<{ community: string, success: boolean, error?: string }>
+```
+
+**Gotchas:**
+- Only throws if ALL communities fail — partial success emits `'key:rotation-partial'` event
+- After rotation, you must update your stored private key to the new one
+- Old key remains valid briefly while contacts update their caches
+
+---
+
+## Key Recovery
+
+```typescript
+await network.recoverKey('owner@example.com', newPublicKeyBase64);
+```
+
+Initiates email-verified recovery with a 1-hour cooling-off period. The relay sends a verification email to the registered owner.
+
+---
+
+## Full Setup Example (Agent-Executable)
+
+```typescript
+import { A2ANetwork } from 'kithkit-a2a-client';
+import { readFileSync } from 'fs';
+
+// 1. Load or generate keys
+let privateKey: string;
+try {
+  privateKey = readFileSync('./keys/a2a-private.key', 'utf-8').trim();
+} catch {
+  const keys = A2ANetwork.generateKeypair();
+  privateKey = keys.privateKey;
+  // Save keys.publicKey for relay registration
+  // Save keys.privateKey securely
+}
+
+// 2. Create client
+const network = new A2ANetwork({
+  relayUrl: 'https://relay.example.com',
+  username: 'my-agent',
+  privateKey: Buffer.from(privateKey, 'base64'),
+  endpoint: 'https://my-agent.example.com/a2a/incoming',
+});
+
+// 3. Wire up event handlers
+network.on('message', (msg) => {
+  console.log(`Message from ${msg.sender}:`, msg.payload);
+});
+
+network.on('contact-request', (req) => {
+  console.log(`Contact request from ${req.from}`);
+});
+
+// 4. Start
+await network.start();
+```

--- a/.claude/skills/agent-comms/SKILL.md
+++ b/.claude/skills/agent-comms/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: agent-comms
-description: Send messages to peer agents and check agent-comms status.
+description: Sends and receives messages with peer agents on the local network. Use when messaging peers, checking peer availability, coordinating shared work, or reviewing agent-comms logs.
 argument-hint: [send <peer> "<message>" | status | log]
 ---
 
 # Agent-to-Agent Communication
 
 Send and receive messages with peer agents on the local network.
+
+> **Scope**: This skill covers A2A peer-to-peer messaging (LAN direct + P2P SDK). For A2A network features (groups, discovery, relay), see the `a2a-network` skill. For Telegram messaging to humans, see the `telegram` skill.
 
 ## Commands
 
@@ -26,26 +28,72 @@ Parse the arguments to determine action:
 - `log <n>` - Show last n log entries
 
 ### Examples
-- `/agent-comms send r2d2 "Hey, are you free to review a PR?"`
-- `/agent-comms send r2d2 "Claiming the auth refactor" coordination`
-- `/agent-comms send r2d2 "idle" status`
+- `/agent-comms send alice "Hey, are you free to review a PR?"`
+- `/agent-comms send alice "Claiming the auth refactor" coordination`
+- `/agent-comms send alice "idle" status`
 - `/agent-comms status`
 - `/agent-comms log 10`
 
 ## Implementation
 
 ### Sending
-Use the CLI script for reliable delivery:
+Send via the daemon's `/agent/send` endpoint (2-tier routing: LAN direct → P2P SDK fallback).
+
+**IMPORTANT:** Always use python3 to generate JSON for curl to avoid shell quoting issues. Raw `--data-raw` with shell-interpolated strings causes "Bad escaped character" JSON parse errors.
+
 ```bash
-scripts/agent-send.sh <peer> "<message>" [type]
+python3 -c "
+import json, subprocess, sys
+data = json.dumps({'peer': '<name>', 'type': 'text', 'text': '<message>'})
+r = subprocess.run(['curl', '-s', '-X', 'POST', 'http://localhost:3847/agent/send',
+  '-H', 'Content-Type: application/json', '-d', data], capture_output=True, text=True)
+print(r.stdout)
+"
 ```
 
-Or via the daemon endpoint (uses curl internally):
-```bash
-curl -s -X POST http://localhost:3847/agent/send \
-  -H 'Content-Type: application/json' \
-  --data-raw '{"peer":"<name>","type":"text","text":"<message>"}'
+**Request fields:**
+| Field | Required | Description |
+|-------|----------|-------------|
+| `peer` | yes | Target peer name (e.g. `alice`) |
+| `type` | yes | `text`, `status`, `coordination`, or `pr-review` |
+| `text` | no | Message body |
+| `status` | no | For status messages (e.g. `idle`, `busy`) |
+| `action` | no | For coordination (e.g. `claim`, `release`) |
+| `task` | no | Task description |
+| `context` | no | Additional context |
+| `callbackUrl` | no | Callback endpoint for async replies |
+| `repo` | no | For PR reviews |
+| `branch` | no | For PR reviews |
+| `pr` | no | PR number string |
+
+**Success response (HTTP 200):**
+```json
+{"ok": true, "queued": false, "error": null}
 ```
+
+**Failure response (HTTP 502):**
+```json
+{"ok": false, "queued": false, "error": "Failed to reach peer alice (peer-host.lan:3847): ..."}
+```
+
+If LAN delivery fails and the P2P SDK is active, the message is sent via P2P and `queued` is `true`.
+
+### Receiving (Inbound)
+Peers send to our `POST /agent/message` endpoint (handled by the daemon automatically). Inbound messages require Bearer auth and must include `messageId` and `timestamp`:
+
+```json
+{
+  "from": "alice",
+  "type": "text",
+  "text": "Hey, PR is ready for review",
+  "messageId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "timestamp": "2026-02-27T15:30:00.000Z"
+}
+```
+
+**Response:** `{"ok": true, "queued": false}`
+
+The daemon validates the Bearer token, formats the message, and injects it into the comms tmux session.
 
 ### Checking Status
 ```bash
@@ -63,26 +111,46 @@ tail -20 logs/agent-comms.log
 
 ## Peers
 
-Peers are configured in `cc4me.config.yaml` under `agent-comms.peers`. Each peer has a name, host, and port.
+Peers are configured in `kithkit.config.yaml` under `agent-comms.peers`. Each peer has a name, host, port, and optional fallback IP.
+
+```yaml
+agent-comms:
+  enabled: true
+  secret: "credential-agent-comms-secret"  # Keychain credential name
+  peers:
+    - name: "alice"
+      host: "alice-machine.lan"
+      port: 3847
+      ip: "192.168.1.100"  # Fallback IP for LAN retry
+```
 
 ## Architecture
 
 ### LAN (Direct)
-- **Inbound**: Daemon receives on `POST /agent/message`, validates auth (bearer token from Keychain), injects directly into tmux session with `[Agent] Name:` prefix (same as Telegram — tmux buffers input natively)
+- **Inbound**: Daemon receives on `POST /agent/message`, validates auth (bearer token from Keychain), injects directly into tmux session with `[Network] Name:` prefix
 - **Outbound**: Daemon sends via `curl` subprocess (not Node.js `http.request`, which has macOS LAN networking issues)
 - **Auth**: Shared secret stored in macOS Keychain (`credential-agent-comms-secret`)
 
-### Relay (Internet Fallback)
-- **Transport**: HTTPS via CC4Me Relay (https://relay.bmobot.ai)
+### P2P SDK (Internet — Primary)
+- **Transport**: HTTPS directly to peer's public endpoint (E2E encrypted)
+- **Encryption**: X25519 ECDH key exchange + AES-256-GCM, Ed25519 signed envelopes
+- **Sending**: If LAN fails and Kithkit A2A Network SDK is active, sends directly to peer via P2P SDK
+- **Receiving**: SDK event handler routes incoming messages to session
+- **Identity**: Agent Ed25519 keypair in Keychain (`credential-kithkit-agent-key`), public key in relay directory
+- **Key point**: Messages go directly between agents — the relay is never in the message path
+
+### Legacy Relay (Deprecated Fallback)
+- **Transport**: HTTPS via Kithkit Relay (configured in `kithkit.config.yaml` under `network.relay_url`) — store-and-forward
 - **Auth**: Ed25519 per-request signatures (X-Agent + X-Signature headers)
-- **Sending**: If LAN fails and `network.enabled` is true, automatically falls back to relay
-- **Receiving**: `relay-inbox-poll` task polls every 30s, verifies signatures, injects messages
-- **Identity**: Agent keypair in Keychain (`credential-cc4me-agent-key`), public key registered with relay
-- **Policy**: No sensitive data over relay until E2E encryption is added (see `docs/relay-usage-policy.md`)
+- **Sending**: Only used if both LAN and P2P SDK fail
+- **Note**: Being deprecated in favor of P2P SDK. Messages through legacy relay are signed but not E2E encrypted
 
 ### Logging
 - All messages logged as JSONL to `logs/agent-comms.log`
 - Directions: `in` (LAN inbound), `out` (LAN outbound), `relay-in`, `relay-out`
+
+### Group Messaging
+For A2A group messaging (broadcast to multiple peers), use the `a2a-network` skill — specifically `POST /api/network/groups/:id/message`. This skill (`agent-comms`) handles only 1:1 peer messaging.
 
 ## Usage Protocol
 

--- a/.claude/skills/agent-comms/messaging-sop.md
+++ b/.claude/skills/agent-comms/messaging-sop.md
@@ -1,0 +1,221 @@
+# A2A Network Messaging SOP
+
+Standard operating procedures for sending and receiving messages via the Kithkit A2A network. All agents must follow this format.
+
+## Quick Reference
+
+| Action | Endpoint | Method |
+|--------|----------|--------|
+| Send text message | `/api/network/message` | POST |
+| Send structured payload | `/api/network/send` | POST |
+| Read inbox | `/api/network/inbox` | GET |
+| Send to group | `/api/network/groups/:id/message` | POST |
+| LAN direct send | `/agent/send` | POST |
+
+## Sending Messages
+
+### Simple Text Message (Preferred)
+
+**IMPORTANT:** Always use python3 to generate JSON for curl. Shell quoting breaks JSON with special characters (quotes, apostrophes, backslashes), causing "Invalid request" errors.
+
+```bash
+python3 -c "
+import json, subprocess
+data = json.dumps({'to': 'peer-name', 'message': 'Hey, PR is ready for review'})
+r = subprocess.run(['curl', '-s', '-X', 'POST', 'http://localhost:3847/api/network/message',
+  '-H', 'Content-Type: application/json', '-d', data], capture_output=True, text=True)
+print(r.stdout)
+"
+```
+
+**Fields:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `to` | string | yes | Recipient username (lowercase) |
+| `message` | string | yes* | Plain text message body |
+| `payload` | object | yes* | Structured payload (alternative to `message`) |
+
+*Provide exactly one of `message` or `payload`.
+
+**Response (200):**
+```json
+{
+  "status": "delivered",
+  "messageId": "a1b2c3d4-...",
+  "timestamp": "2026-03-01T07:30:00.000Z"
+}
+```
+
+Status values: `delivered`, `queued`, `failed`
+
+### Structured Payload
+
+Use `payload` when you need to send typed/structured data:
+
+```bash
+curl -s -X POST http://localhost:3847/api/network/message \
+  -H "Content-Type: application/json" \
+  -d '{"to": "peer-name", "payload": {"type": "coordination", "action": "claim", "task": "feature-audit-scheduler"}}'
+```
+
+### Group Message
+
+```bash
+curl -s -X POST http://localhost:3847/api/network/groups/team-kithkit/message \
+  -H "Content-Type: application/json" \
+  -d '{"payload": {"type": "message", "text": "Sync: all PRs merged to main"}}'
+```
+
+**Response (200):**
+```json
+{
+  "messageId": "uuid",
+  "delivered": ["alice", "bob"],
+  "queued": [],
+  "failed": []
+}
+```
+
+## Reading Inbox
+
+```bash
+# Latest 50 messages (default)
+curl -s http://localhost:3847/api/network/inbox
+
+# Last 10 messages
+curl -s "http://localhost:3847/api/network/inbox?limit=10"
+
+# Messages since a timestamp
+curl -s "http://localhost:3847/api/network/inbox?since=2026-03-01T06:00:00&limit=20"
+```
+
+**Response (200):**
+```json
+{
+  "messages": [
+    {
+      "id": 123,
+      "from_agent": "network:alice",
+      "to_agent": "comms",
+      "type": "text",
+      "body": "[Network] alice: PR merged, tests passing",
+      "metadata": "{\"source\":\"a2a-network\",\"sender\":\"alice\",\"messageId\":\"uuid\",\"verified\":true}",
+      "created_at": "2026-03-01 07:30:00",
+      "processed_at": "2026-03-01 07:30:05",
+      "read_at": null
+    }
+  ],
+  "count": 1,
+  "timestamp": "2026-03-01T07:30:10.000Z"
+}
+```
+
+The inbox works even if the A2A SDK is offline — it reads from the local database.
+
+## LAN Direct Send (Fallback)
+
+For peers on the same LAN, use `/agent/send` (2-tier: LAN direct, P2P SDK fallback):
+
+```bash
+curl -s -X POST http://localhost:3847/agent/send \
+  -H "Content-Type: application/json" \
+  -d '{"peer": "alice", "type": "text", "text": "Quick LAN ping"}'
+```
+
+See the main SKILL.md for full LAN endpoint documentation.
+
+## Common Mistakes
+
+### 1. Sending message as JSON object instead of string
+
+```bash
+# WRONG — message must be a string, not an object
+curl -d '{"to": "alice", "message": {"text": "hello"}}'
+#                                   ^^^^^^^^^^^^^^^^ object = 400 error
+
+# CORRECT — message is a plain string
+curl -d '{"to": "alice", "message": "hello"}'
+#                        ^^^^^^^^^ string = works
+```
+
+The `message` field is a **string**. If you need to send structured data, use `payload` (an object) instead.
+
+### 2. Using uppercase usernames
+
+```bash
+# WRONG
+curl -d '{"to": "Alice", "message": "hey"}'
+
+# CORRECT — always lowercase
+curl -d '{"to": "alice", "message": "hey"}'
+```
+
+### 3. Omitting both message and payload
+
+```bash
+# WRONG — returns 400
+curl -d '{"to": "alice"}'
+
+# CORRECT — must include one
+curl -d '{"to": "alice", "message": "hello"}'
+```
+
+### 4. Shell quoting issues with curl
+
+Use `python3` to generate JSON for complex messages:
+
+```bash
+python3 -c "
+import json, subprocess
+data = json.dumps({'to': 'alice', 'message': 'Message with \"quotes\" and special chars'})
+subprocess.run(['curl', '-s', '-X', 'POST', 'http://localhost:3847/api/network/message',
+  '-H', 'Content-Type: application/json', '-d', data])
+"
+```
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Bad request (missing field, wrong type, invalid JSON) |
+| 413 | Request body too large |
+| 502 | Network SDK error (relay unreachable) |
+| 503 | Network SDK not initialized |
+
+## Message Flow
+
+```
+Outbound: Agent → POST /api/network/message → SDK → Relay → Peer SDK → Peer Agent
+Inbound:  Peer SDK → /agent/p2p → SDK decrypt → messages DB → tmux injection
+```
+
+All messages (in/out) are persisted in the `messages` table for audit and retrieval.
+
+## Choosing the Right Endpoint — Full Map
+
+| Endpoint | Method | Purpose | Auth | Scope |
+|----------|--------|---------|------|-------|
+| `/agent/send` | POST | LAN direct send to a peer (2-tier: LAN → P2P fallback) | None (localhost only) | P2P |
+| `/api/network/message` | POST | Send via A2A network SDK (P2P encrypted) | None (localhost only) | P2P |
+| `/api/network/groups/:id/message` | POST | Broadcast to an A2A group | None (localhost only) | Group |
+| `/api/network/inbox` | GET | Read received A2A messages | None (localhost only) | P2P + Group |
+| `/api/send` | POST | Channel router — deliver to human via Telegram/email | None (localhost only) | Human |
+| `/api/messages` | POST | Internal daemon message bus (comms ↔ orchestrator ↔ workers) | None (localhost only) | Internal |
+| `/api/messages` | GET | Read internal message history | None (localhost only) | Internal |
+
+### When to Use What
+
+| I want to... | Use |
+|--------------|-----|
+| Send a quick message to a peer | `/agent/send` (fastest, LAN-first) or `/api/network/message` (SDK, always encrypted) |
+| Broadcast to all peers | `/api/network/groups/:id/message` with group name |
+| Send a Telegram message to Dave | `/api/send` with `channels: ["telegram"]` |
+| Send an email to Dave | `/api/send` with `channels: ["email"]` |
+| Post an internal message (comms ↔ orchestrator) | `/api/messages` |
+| Read my A2A inbox | `/api/network/inbox` |
+| Read internal messages | `/api/messages?agent=comms` |
+
+## Agent Usernames
+
+Configure agent usernames in `kithkit.config.yaml` under `agent-comms.peers`. Usernames must be lowercase.


### PR DESCRIPTION
## Summary
- Add `.claude/skills/a2a-network/` directory with 6 reference files (SKILL.md dispatcher, connections.md, discovery.md, groups.md, messaging.md, setup.md) covering the full Kithkit A2A Network SDK surface
- Add `.claude/skills/agent-comms/messaging-sop.md` with standard operating procedures for A2A messaging endpoints
- Update `.claude/skills/agent-comms/SKILL.md` with P2P SDK architecture, genericized examples (no hardcoded IPs/hostnames), and scope clarification separating agent-comms (P2P) from a2a-network (groups/discovery/relay)

## Context
A2A uniformity audit found that agent instances diverged on skill documentation — some were missing the entire a2a-network skill directory and the messaging SOP. This PR adds these as canonical upstream templates so all kithkit instances get them on sync.

All agent-specific references (hostnames, IPs, peer names like `r2d2`/`skippy`) have been replaced with generic placeholders (`alice`, `bob`, `peer-name`, `alice-machine.lan`, `192.168.1.100`).

## Files Added/Changed
| File | Change |
|------|--------|
| `.claude/skills/a2a-network/SKILL.md` | **New** — keyword dispatcher routing to reference files |
| `.claude/skills/a2a-network/connections.md` | **New** — contact management (request, accept, deny, remove, list) |
| `.claude/skills/a2a-network/discovery.md` | **New** — presence, heartbeats, broadcasts, community health |
| `.claude/skills/a2a-network/groups.md` | **New** — group creation, membership, group messaging, daemon HTTP API |
| `.claude/skills/a2a-network/messaging.md` | **New** — E2E encrypted messaging, delivery tracking, retry queue |
| `.claude/skills/a2a-network/setup.md` | **New** — SDK installation, keypair generation, client configuration |
| `.claude/skills/agent-comms/SKILL.md` | **Updated** — genericized peers, added P2P SDK architecture, scope note |
| `.claude/skills/agent-comms/messaging-sop.md` | **New** — endpoint map, common mistakes, message flow |

## Test plan
- [ ] Verify no instance-specific references remain (grep for hardcoded IPs, hostnames, agent names)
- [ ] Confirm SKILL.md routing table links resolve to correct reference files
- [ ] Review agent-comms/SKILL.md for cc4me → kithkit config references

🤖 Generated with [Claude Code](https://claude.com/claude-code)