### PR TITLE
fix: scheduler in-process persistence + peer-heartbeat core registration

### DIFF
--- a/daemon/src/automation/scheduler.ts
+++ b/daemon/src/automation/scheduler.ts
@@ -11,6 +11,7 @@ import { parseInterval, type TaskScheduleConfig } from '../core/config.js';
 import { runTask, type TaskResult } from './task-runner.js';
 import { registerCoreTasks, loadExternalTasks, type LoadResult } from './tasks/index.js';
 import { createLogger } from '../core/logger.js';
+import { exec as dbExec, query } from '../core/db.js';
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -374,25 +375,48 @@ export class Scheduler {
     try {
       await handler({ taskName: task.name, config: task.config });
       const durationMs = Date.now() - start;
-      return {
+      const finishedAt = new Date().toISOString();
+
+      // Persist to DB (same pattern as runTask in task-runner.ts)
+      dbExec(
+        'INSERT INTO task_results (task_name, status, output, duration_ms, started_at, finished_at) VALUES (?, ?, ?, ?, ?, ?)',
+        task.name, 'success', 'In-process handler completed', durationMs, startedAt, finishedAt,
+      );
+      const rows = query<TaskResult>(
+        'SELECT * FROM task_results WHERE task_name = ? ORDER BY id DESC LIMIT 1',
+        task.name,
+      );
+      return rows[0] ?? {
         id: 0,
         task_name: task.name,
         status: 'success',
         output: 'In-process handler completed',
         duration_ms: durationMs,
         started_at: startedAt,
-        finished_at: new Date().toISOString(),
+        finished_at: finishedAt,
       };
     } catch (err) {
       const durationMs = Date.now() - start;
-      return {
+      const finishedAt = new Date().toISOString();
+      const output = err instanceof Error ? err.message : String(err);
+
+      // Persist to DB
+      dbExec(
+        'INSERT INTO task_results (task_name, status, output, duration_ms, started_at, finished_at) VALUES (?, ?, ?, ?, ?, ?)',
+        task.name, 'failure', output, durationMs, startedAt, finishedAt,
+      );
+      const rows = query<TaskResult>(
+        'SELECT * FROM task_results WHERE task_name = ? ORDER BY id DESC LIMIT 1',
+        task.name,
+      );
+      return rows[0] ?? {
         id: 0,
         task_name: task.name,
         status: 'failure',
-        output: err instanceof Error ? err.message : String(err),
+        output,
         duration_ms: durationMs,
         started_at: startedAt,
-        finished_at: new Date().toISOString(),
+        finished_at: finishedAt,
       };
     }
   }

--- a/daemon/src/automation/tasks/index.ts
+++ b/daemon/src/automation/tasks/index.ts
@@ -17,6 +17,7 @@ import { register as registerBackup } from './backup.js';
 import { register as registerOrchestratorIdle } from './orchestrator-idle.js';
 import { register as registerMessageDelivery } from './message-delivery.js';
 import { register as registerCommsHeartbeat } from './comms-heartbeat.js';
+import { register as registerPeerHeartbeat } from './peer-heartbeat.js';
 export { loadExternalTasks, type LoadResult } from './external-loader.js';
 
 /**
@@ -33,6 +34,7 @@ export function registerCoreTasks(scheduler: Scheduler): void {
     { name: 'orchestrator-idle', register: registerOrchestratorIdle },
     { name: 'message-delivery', register: registerMessageDelivery },
     { name: 'comms-heartbeat', register: registerCommsHeartbeat },
+    { name: 'peer-heartbeat', register: registerPeerHeartbeat },
   ];
 
   for (const { name, register } of registrations) {

--- a/daemon/src/automation/tasks/peer-heartbeat.ts
+++ b/daemon/src/automation/tasks/peer-heartbeat.ts
@@ -4,21 +4,33 @@
  * Every 5 minutes (configurable), sends a `status` type message to each peer
  * via `sendAgentMessage`. Updates peer state based on responses.
  *
+ * Uses dynamic imports for agent-comms so the task skips gracefully when
+ * the agent-comms extension is not loaded.
+ *
  * Uses message type `status` (not `ping` — valid types are:
  * text, status, coordination, pr-review).
  */
 
-import { createLogger } from '../../../core/logger.js';
-import { loadConfig } from '../../../core/config.js';
-import { asR2Config } from '../../config.js';
-import { sendAgentMessage, updatePeerState } from '../../comms/agent-comms.js';
-import type { Scheduler } from '../../../automation/scheduler.js';
+import { createLogger } from '../../core/logger.js';
+import { loadConfig } from '../../core/config.js';
+import type { Scheduler } from '../scheduler.js';
 
 const log = createLogger('peer-heartbeat');
 
+interface PeerConfig {
+  name: string;
+  host: string;
+  port: number;
+}
+
+interface AgentCommsConfig {
+  enabled: boolean;
+  peers?: PeerConfig[];
+}
+
 async function run(): Promise<void> {
-  const config = asR2Config(loadConfig());
-  const agentComms = config['agent-comms'];
+  const config = loadConfig();
+  const agentComms = (config as unknown as Record<string, unknown>)['agent-comms'] as AgentCommsConfig | undefined;
 
   if (!agentComms?.enabled) {
     log.debug('Agent comms disabled, skipping heartbeat');
@@ -31,24 +43,34 @@ async function run(): Promise<void> {
     return;
   }
 
+  // Dynamic import — agent-comms module may not exist if the extension isn't installed
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let comms: any;
+  try {
+    comms = await import('../../extensions/comms/agent-comms.js');
+  } catch {
+    log.debug('Agent-comms module not available, skipping heartbeat');
+    return;
+  }
+
   let sent = 0;
   let failed = 0;
 
   for (const peer of peers) {
     try {
-      const result = await sendAgentMessage(peer.name, 'status', undefined, {
+      const result = await comms.sendAgentMessage(peer.name, 'status', undefined, {
         status: 'idle',
       });
 
       if (result.ok) {
-        updatePeerState(peer.name, {
+        comms.updatePeerState(peer.name, {
           status: 'idle',
           updatedAt: Date.now(),
         });
         sent++;
         log.debug(`Heartbeat sent to ${peer.name}`, { queued: result.queued });
       } else {
-        updatePeerState(peer.name, {
+        comms.updatePeerState(peer.name, {
           status: 'unknown',
           updatedAt: Date.now(),
         });
@@ -56,7 +78,7 @@ async function run(): Promise<void> {
         log.debug(`Heartbeat failed for ${peer.name}`, { error: result.error });
       }
     } catch (err) {
-      updatePeerState(peer.name, {
+      comms.updatePeerState(peer.name, {
         status: 'unknown',
         updatedAt: Date.now(),
       });

--- a/daemon/src/extensions/automation/tasks/index.ts
+++ b/daemon/src/extensions/automation/tasks/index.ts
@@ -11,7 +11,6 @@
 
 import type { Scheduler } from '../../../automation/scheduler.js';
 
-import { register as registerPeerHeartbeat } from './peer-heartbeat.js';
 import { register as registerMemoryConsolidation } from './memory-consolidation.js';
 
 /**
@@ -23,7 +22,6 @@ import { register as registerMemoryConsolidation } from './memory-consolidation.
  */
 export function registerR2Tasks(scheduler: Scheduler): void {
   const registrations: Array<[string, (s: Scheduler) => void]> = [
-    ['peer-heartbeat', registerPeerHeartbeat],
     ['memory-consolidation', registerMemoryConsolidation],
   ];
 
@@ -36,6 +34,5 @@ export function registerR2Tasks(scheduler: Scheduler): void {
 
 /** Task names that have real implementations (used to skip stubs). */
 export const REAL_TASK_NAMES = new Set([
-  'peer-heartbeat',
   'memory-consolidation',
 ]);

--- a/daemon/src/extensions/index.ts
+++ b/daemon/src/extensions/index.ts
@@ -283,7 +283,7 @@ function registerR2HealthChecks(): void {
 const R2_TASK_HANDLERS = [
   'health-check',
   'memory-consolidation',
-  'peer-heartbeat',
+
   'weekly-progress-report',
 ] as const;
 


### PR DESCRIPTION
## Summary

Fixes #105 — two scheduler bugs:

- **Bug A**: `_runInProcess()` now persists task results to `task_results` DB table via `INSERT INTO task_results`, matching `runTask()` behavior in `task-runner.ts`. Previously in-process tasks (context-watchdog, orchestrator-idle, comms-heartbeat, etc.) appeared to never run when querying the database.
- **Bug B**: Moved `peer-heartbeat` handler from extension-only `registerR2Tasks()` to core `registerCoreTasks()`, so any Kithkit agent with `agent-comms.enabled: true` gets automatic peer heartbeat. Uses dynamic import for `agent-comms` module so it skips gracefully when the extension is not installed.

## Changes

| File | Change |
|------|--------|
| `scheduler.ts` | Import `dbExec`/`query`, add DB insert + row fetch in `_runInProcess()` |
| `automation/tasks/peer-heartbeat.ts` | **Moved** from `extensions/` — core version with dynamic import for agent-comms |
| `automation/tasks/index.ts` | Add `peer-heartbeat` to `registerCoreTasks()` |
| `extensions/automation/tasks/index.ts` | Remove `peer-heartbeat` from `registerR2Tasks()` and `REAL_TASK_NAMES` |
| `extensions/index.ts` | Remove `peer-heartbeat` from `R2_TASK_HANDLERS` stub list |

## Test plan

- [ ] `tsc --noEmit` passes (only pre-existing sdk-bridge error, no new errors)
- [ ] In-process tasks (context-watchdog, orchestrator-idle, etc.) now produce rows in `task_results` table
- [ ] peer-heartbeat works on non-R2 agents (Skippy, BMO) without subprocess fallback failures
- [ ] R2 extension continues to work (peer-heartbeat registered by core, not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)