### PR TITLE
feat: API metrics system with dashboard

### DIFF
--- a/daemon/public/metrics.html
+++ b/daemon/public/metrics.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>API Metrics Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --text-muted: #8b949e;
+      --accent: #58a6ff;
+      --green: #3fb950;
+      --red: #f85149;
+      --orange: #d29922;
+      --purple: #bc8cff;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      padding: 24px;
+      line-height: 1.5;
+    }
+    h1 { font-size: 24px; font-weight: 600; margin-bottom: 8px; }
+    h2 { font-size: 16px; font-weight: 600; margin-bottom: 12px; color: var(--text-muted); }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 24px;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    .controls {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
+    .controls select, .controls button {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      color: var(--text);
+      padding: 6px 12px;
+      border-radius: 6px;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    .controls button:hover { border-color: var(--accent); }
+    .controls button.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+    .summary-cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .card .label { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; }
+    .card .value { font-size: 28px; font-weight: 700; margin-top: 4px; }
+    .card .value.green { color: var(--green); }
+    .card .value.red { color: var(--red); }
+    .card .value.orange { color: var(--orange); }
+    .card .value.accent { color: var(--accent); }
+    .chart-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+    @media (max-width: 900px) {
+      .chart-grid { grid-template-columns: 1fr; }
+    }
+    .chart-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .chart-card.full { grid-column: 1 / -1; }
+    .chart-card canvas { max-height: 300px; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    th {
+      text-align: left;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+      color: var(--text-muted);
+      font-weight: 600;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    td {
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+    }
+    tr:hover td { background: rgba(88, 166, 255, 0.04); }
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 11px;
+      font-weight: 600;
+    }
+    .badge.error { background: rgba(248, 81, 73, 0.15); color: var(--red); }
+    .badge.warn { background: rgba(210, 153, 34, 0.15); color: var(--orange); }
+    .badge.ok { background: rgba(63, 185, 80, 0.15); color: var(--green); }
+    .loading {
+      text-align: center;
+      padding: 40px;
+      color: var(--text-muted);
+    }
+    .error-msg {
+      background: rgba(248, 81, 73, 0.1);
+      border: 1px solid var(--red);
+      border-radius: 8px;
+      padding: 16px;
+      color: var(--red);
+      margin-bottom: 24px;
+    }
+    .timestamp {
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div>
+      <h1>API Metrics</h1>
+      <span class="timestamp" id="lastUpdated"></span>
+    </div>
+    <div class="controls">
+      <select id="hoursSelect">
+        <option value="6">Last 6 hours</option>
+        <option value="12">Last 12 hours</option>
+        <option value="24" selected>Last 24 hours</option>
+        <option value="48">Last 48 hours</option>
+        <option value="168">Last 7 days</option>
+      </select>
+      <button id="refreshBtn" onclick="loadData()">Refresh</button>
+    </div>
+  </div>
+
+  <div id="errorContainer"></div>
+
+  <div class="summary-cards" id="summaryCards">
+    <div class="card"><div class="label">Total Requests</div><div class="value accent" id="totalReqs">-</div></div>
+    <div class="card"><div class="label">Success Rate</div><div class="value green" id="successRate">-</div></div>
+    <div class="card"><div class="label">4xx Errors</div><div class="value orange" id="errors4xx">-</div></div>
+    <div class="card"><div class="label">5xx Errors</div><div class="value red" id="errors5xx">-</div></div>
+    <div class="card"><div class="label">Avg Latency</div><div class="value accent" id="avgLatency">-</div></div>
+  </div>
+
+  <div class="chart-grid">
+    <div class="chart-card full">
+      <h2>Request Volume & Errors Over Time</h2>
+      <canvas id="volumeChart"></canvas>
+    </div>
+    <div class="chart-card">
+      <h2>Latency Over Time</h2>
+      <canvas id="latencyChart"></canvas>
+    </div>
+    <div class="chart-card">
+      <h2>Requests by Agent</h2>
+      <canvas id="agentChart"></canvas>
+    </div>
+  </div>
+
+  <div class="chart-grid">
+    <div class="chart-card">
+      <h2>Top Endpoints</h2>
+      <div id="endpointTable"></div>
+    </div>
+    <div class="chart-card">
+      <h2>Top Errors</h2>
+      <div id="errorsTable"></div>
+    </div>
+  </div>
+
+  <div class="chart-grid" id="repeatSection" style="display:none;">
+    <div class="chart-card full">
+      <h2>Repeat Offenders</h2>
+      <div id="repeatTable"></div>
+    </div>
+  </div>
+
+  <script>
+    let volumeChart = null;
+    let latencyChart = null;
+    let agentChart = null;
+
+    const chartDefaults = {
+      color: '#8b949e',
+      borderColor: '#30363d',
+    };
+
+    Chart.defaults.color = chartDefaults.color;
+    Chart.defaults.borderColor = chartDefaults.borderColor;
+
+    function formatNum(n) {
+      if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+      if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+      return n.toString();
+    }
+
+    function formatMs(ms) {
+      if (ms >= 1000) return (ms / 1000).toFixed(1) + 's';
+      return Math.round(ms) + 'ms';
+    }
+
+    function formatHour(h) {
+      try {
+        const d = new Date(h.replace(' ', 'T') + ':00Z');
+        return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+      } catch {
+        return h;
+      }
+    }
+
+    function buildTable(headers, rows) {
+      if (rows.length === 0) return '<p style="color:var(--text-muted);padding:12px;">No data</p>';
+      let html = '<table><thead><tr>';
+      for (const h of headers) html += `<th>${h.label}</th>`;
+      html += '</tr></thead><tbody>';
+      for (const row of rows) {
+        html += '<tr>';
+        for (const h of headers) html += `<td>${h.render(row)}</td>`;
+        html += '</tr>';
+      }
+      html += '</tbody></table>';
+      return html;
+    }
+
+    async function loadData() {
+      const hours = document.getElementById('hoursSelect').value;
+      const errorContainer = document.getElementById('errorContainer');
+      errorContainer.innerHTML = '';
+
+      try {
+        const resp = await fetch(`/api/metrics?hours=${hours}`);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+        const data = await resp.json();
+
+        document.getElementById('lastUpdated').textContent = `Updated: ${new Date(data.timestamp).toLocaleString()}`;
+
+        // Summary cards
+        const s = data.summary;
+        document.getElementById('totalReqs').textContent = formatNum(s.total_requests);
+        const rate = s.total_requests > 0 ? ((s.success_count / s.total_requests) * 100).toFixed(1) : '0.0';
+        document.getElementById('successRate').textContent = rate + '%';
+        document.getElementById('errors4xx').textContent = formatNum(s.error_4xx);
+        document.getElementById('errors5xx').textContent = formatNum(s.error_5xx);
+        document.getElementById('avgLatency').textContent = formatMs(s.avg_latency_ms);
+
+        // Volume chart
+        const hourly = data.hourly || [];
+        const labels = hourly.map(h => formatHour(h.hour));
+        const reqData = hourly.map(h => h.total_requests);
+        const err4Data = hourly.map(h => h.error_4xx);
+        const err5Data = hourly.map(h => h.error_5xx);
+
+        if (volumeChart) volumeChart.destroy();
+        volumeChart = new Chart(document.getElementById('volumeChart'), {
+          type: 'bar',
+          data: {
+            labels,
+            datasets: [
+              {
+                label: 'Successful',
+                data: hourly.map(h => h.success_count),
+                backgroundColor: 'rgba(63, 185, 80, 0.6)',
+                borderRadius: 2,
+              },
+              {
+                label: '4xx Errors',
+                data: err4Data,
+                backgroundColor: 'rgba(210, 153, 34, 0.6)',
+                borderRadius: 2,
+              },
+              {
+                label: '5xx Errors',
+                data: err5Data,
+                backgroundColor: 'rgba(248, 81, 73, 0.6)',
+                borderRadius: 2,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { position: 'top' } },
+            scales: {
+              x: { stacked: true, ticks: { maxRotation: 45, font: { size: 10 } } },
+              y: { stacked: true, beginAtZero: true },
+            },
+          },
+        });
+
+        // Latency chart
+        const latData = hourly.map(h => h.avg_latency_ms);
+
+        if (latencyChart) latencyChart.destroy();
+        latencyChart = new Chart(document.getElementById('latencyChart'), {
+          type: 'line',
+          data: {
+            labels,
+            datasets: [{
+              label: 'Avg Latency (ms)',
+              data: latData,
+              borderColor: '#58a6ff',
+              backgroundColor: 'rgba(88, 166, 255, 0.1)',
+              fill: true,
+              tension: 0.3,
+              pointRadius: 2,
+            }],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { display: false } },
+            scales: {
+              x: { ticks: { maxRotation: 45, font: { size: 10 } } },
+              y: { beginAtZero: true, title: { display: true, text: 'ms' } },
+            },
+          },
+        });
+
+        // Agent chart
+        const agents = data.agents || [];
+        if (agentChart) agentChart.destroy();
+        if (agents.length > 0) {
+          const colors = ['#58a6ff', '#3fb950', '#d29922', '#f85149', '#bc8cff', '#f0883e', '#79c0ff'];
+          agentChart = new Chart(document.getElementById('agentChart'), {
+            type: 'doughnut',
+            data: {
+              labels: agents.map(a => a.agent_id),
+              datasets: [{
+                data: agents.map(a => a.total_requests),
+                backgroundColor: agents.map((_, i) => colors[i % colors.length]),
+                borderWidth: 0,
+              }],
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: { position: 'right', labels: { font: { size: 11 } } },
+              },
+            },
+          });
+        }
+
+        // Endpoint table
+        const endpoints = (data.endpoints || []).slice(0, 15);
+        document.getElementById('endpointTable').innerHTML = buildTable(
+          [
+            { label: 'Endpoint', render: r => `<code>${r.method} ${r.endpoint}</code>` },
+            { label: 'Requests', render: r => formatNum(r.total_requests) },
+            { label: '4xx', render: r => r.error_4xx > 0 ? `<span class="badge warn">${r.error_4xx}</span>` : '-' },
+            { label: '5xx', render: r => r.error_5xx > 0 ? `<span class="badge error">${r.error_5xx}</span>` : '-' },
+            { label: 'Avg', render: r => formatMs(r.avg_latency_ms) },
+            { label: 'p95', render: r => formatMs(r.p95_latency_ms) },
+          ],
+          endpoints,
+        );
+
+        // Errors table
+        const topErrors = (data.top_errors || []).slice(0, 10);
+        document.getElementById('errorsTable').innerHTML = buildTable(
+          [
+            { label: 'Endpoint', render: r => `<code>${r.method} ${r.endpoint}</code>` },
+            { label: 'Errors', render: r => `<span class="badge error">${r.total_errors}</span>` },
+          ],
+          topErrors,
+        );
+
+        // Repeat offenders
+        const repeats = data.repeat_offenders || [];
+        if (repeats.length > 0) {
+          document.getElementById('repeatSection').style.display = '';
+          document.getElementById('repeatTable').innerHTML = buildTable(
+            [
+              { label: 'Agent', render: r => `<code>${r.agent_id}</code>` },
+              { label: 'Endpoint', render: r => `<code>${r.method} ${r.endpoint}</code>` },
+              { label: 'Errors', render: r => `<span class="badge error">${r.error_count}</span>` },
+              { label: 'Latest', render: r => formatHour(r.latest_hour) },
+            ],
+            repeats,
+          );
+        } else {
+          document.getElementById('repeatSection').style.display = 'none';
+        }
+
+      } catch (err) {
+        errorContainer.innerHTML = `<div class="error-msg">Failed to load metrics: ${err.message}</div>`;
+      }
+    }
+
+    // Auto-refresh every 60 seconds
+    loadData();
+    setInterval(loadData, 60000);
+  </script>
+</body>
+</html>

--- a/daemon/src/api/metrics.ts
+++ b/daemon/src/api/metrics.ts
@@ -1,0 +1,304 @@
+/**
+ * API Metrics — request logging and metrics endpoint.
+ *
+ * Two responsibilities:
+ * 1. logRequest() — called from main.ts after each request to record method,
+ *    path, status, latency, agent, and error field names.
+ * 2. handleMetricsRoute() — serves GET /api/metrics with aggregated data.
+ */
+
+import type http from 'node:http';
+import { exec, query } from '../core/db.js';
+import { json, withTimestamp, parseBody } from './helpers.js';
+import { createLogger } from '../core/logger.js';
+
+const log = createLogger('api-metrics');
+
+// ── Request Logging ──────────────────────────────────────────
+
+/**
+ * Extract agent identifier from request headers.
+ * Checks X-Agent first, then falls back to User-Agent.
+ */
+function extractAgentId(req: http.IncomingMessage): string | null {
+  const xAgent = req.headers['x-agent'];
+  if (typeof xAgent === 'string' && xAgent.length > 0) return xAgent;
+  const ua = req.headers['user-agent'];
+  if (typeof ua === 'string' && ua.length > 0) return ua;
+  return null;
+}
+
+/**
+ * Log a completed request to api_request_logs.
+ * Called from main.ts after each response is sent.
+ *
+ * On 4xx responses, logs the top-level field names from the request body
+ * (not values) to help diagnose bad requests.
+ */
+export function logRequest(
+  req: http.IncomingMessage,
+  statusCode: number,
+  latencyMs: number,
+  bodyFieldNames?: string[] | null,
+): void {
+  try {
+    const method = req.method ?? 'UNKNOWN';
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const path = url.pathname;
+    const agentId = extractAgentId(req);
+
+    // Only record field names on 4xx errors
+    const errorFields = statusCode >= 400 && statusCode < 500 && bodyFieldNames?.length
+      ? JSON.stringify(bodyFieldNames)
+      : null;
+
+    exec(
+      `INSERT INTO api_request_logs (method, path, status_code, latency_ms, agent_id, error_fields)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      method,
+      path,
+      statusCode,
+      latencyMs,
+      agentId,
+      errorFields,
+    );
+  } catch (err) {
+    // Never let metrics logging break a request
+    log.error('Failed to log request', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// ── Metrics Endpoint ─────────────────────────────────────────
+
+interface HourlyRow {
+  hour: string;
+  endpoint: string;
+  method: string;
+  total_requests: number;
+  success_count: number;
+  error_4xx: number;
+  error_5xx: number;
+  avg_latency_ms: number;
+  p95_latency_ms: number;
+  agent_id: string | null;
+}
+
+interface RepeatOffenderRow {
+  agent_id: string;
+  endpoint: string;
+  method: string;
+  error_count: number;
+  latest_hour: string;
+}
+
+/**
+ * Handle GET /api/metrics — returns aggregated metrics data.
+ *
+ * Query parameters:
+ * - endpoint: filter by endpoint path
+ * - agent: filter by agent_id
+ * - from: start time (ISO 8601 or YYYY-MM-DD HH)
+ * - to: end time (ISO 8601 or YYYY-MM-DD HH)
+ * - hours: number of hours to look back (default: 24)
+ */
+export async function handleMetricsRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  pathname: string,
+  searchParams: URLSearchParams,
+): Promise<boolean> {
+  if (!pathname.startsWith('/api/metrics')) return false;
+  const method = req.method ?? '';
+
+  // GET /api/metrics — aggregated data
+  if (pathname === '/api/metrics' && method === 'GET') {
+    const endpointFilter = searchParams.get('endpoint');
+    const agentFilter = searchParams.get('agent');
+    const fromParam = searchParams.get('from');
+    const toParam = searchParams.get('to');
+    const hoursParam = searchParams.get('hours');
+    const hours = hoursParam ? parseInt(hoursParam, 10) : 24;
+
+    // Build WHERE clause
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (fromParam) {
+      conditions.push('hour >= ?');
+      params.push(fromParam);
+    } else {
+      conditions.push("hour >= datetime('now', ?)")
+      params.push(`-${hours} hours`);
+    }
+    if (toParam) {
+      conditions.push('hour <= ?');
+      params.push(toParam);
+    }
+    if (endpointFilter) {
+      conditions.push('endpoint = ?');
+      params.push(endpointFilter);
+    }
+    if (agentFilter) {
+      conditions.push('agent_id = ?');
+      params.push(agentFilter);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    // Summary stats
+    const summaryRows = query<{
+      total_requests: number;
+      success_count: number;
+      error_4xx: number;
+      error_5xx: number;
+      avg_latency: number;
+    }>(
+      `SELECT
+         COALESCE(SUM(total_requests), 0) as total_requests,
+         COALESCE(SUM(success_count), 0) as success_count,
+         COALESCE(SUM(error_4xx), 0) as error_4xx,
+         COALESCE(SUM(error_5xx), 0) as error_5xx,
+         CASE WHEN SUM(total_requests) > 0
+           THEN SUM(avg_latency_ms * total_requests) / SUM(total_requests)
+           ELSE 0 END as avg_latency
+       FROM api_metrics_hourly ${where}`,
+      ...params,
+    );
+    const summary = summaryRows[0] ?? { total_requests: 0, success_count: 0, error_4xx: 0, error_5xx: 0, avg_latency: 0 };
+
+    // Hourly breakdown
+    const hourlyBreakdown = query<{
+      hour: string;
+      total_requests: number;
+      success_count: number;
+      error_4xx: number;
+      error_5xx: number;
+      avg_latency_ms: number;
+    }>(
+      `SELECT
+         hour,
+         SUM(total_requests) as total_requests,
+         SUM(success_count) as success_count,
+         SUM(error_4xx) as error_4xx,
+         SUM(error_5xx) as error_5xx,
+         CASE WHEN SUM(total_requests) > 0
+           THEN SUM(avg_latency_ms * total_requests) / SUM(total_requests)
+           ELSE 0 END as avg_latency_ms
+       FROM api_metrics_hourly ${where}
+       GROUP BY hour ORDER BY hour`,
+      ...params,
+    );
+
+    // Per-endpoint breakdown
+    const endpointBreakdown = query<{
+      endpoint: string;
+      method: string;
+      total_requests: number;
+      error_4xx: number;
+      error_5xx: number;
+      avg_latency_ms: number;
+      p95_latency_ms: number;
+    }>(
+      `SELECT
+         endpoint,
+         method,
+         SUM(total_requests) as total_requests,
+         SUM(error_4xx) as error_4xx,
+         SUM(error_5xx) as error_5xx,
+         CASE WHEN SUM(total_requests) > 0
+           THEN SUM(avg_latency_ms * total_requests) / SUM(total_requests)
+           ELSE 0 END as avg_latency_ms,
+         MAX(p95_latency_ms) as p95_latency_ms
+       FROM api_metrics_hourly ${where}
+       GROUP BY endpoint, method
+       ORDER BY SUM(total_requests) DESC`,
+      ...params,
+    );
+
+    // Per-agent breakdown
+    const agentBreakdown = query<{
+      agent_id: string;
+      total_requests: number;
+      error_4xx: number;
+      error_5xx: number;
+      avg_latency_ms: number;
+    }>(
+      `SELECT
+         COALESCE(agent_id, 'unknown') as agent_id,
+         SUM(total_requests) as total_requests,
+         SUM(error_4xx) as error_4xx,
+         SUM(error_5xx) as error_5xx,
+         CASE WHEN SUM(total_requests) > 0
+           THEN SUM(avg_latency_ms * total_requests) / SUM(total_requests)
+           ELSE 0 END as avg_latency_ms
+       FROM api_metrics_hourly ${where}
+       GROUP BY agent_id
+       ORDER BY SUM(total_requests) DESC`,
+      ...params,
+    );
+
+    // Top error endpoints
+    const topErrors = query<{
+      endpoint: string;
+      method: string;
+      total_errors: number;
+    }>(
+      `SELECT
+         endpoint,
+         method,
+         SUM(error_4xx + error_5xx) as total_errors
+       FROM api_metrics_hourly ${where}
+       GROUP BY endpoint, method
+       HAVING total_errors > 0
+       ORDER BY total_errors DESC
+       LIMIT 10`,
+      ...params,
+    );
+
+    // Repeat offenders: same agent + same endpoint + errors across multiple hours
+    const repeatOffenders = query<RepeatOffenderRow>(
+      `SELECT
+         agent_id,
+         endpoint,
+         method,
+         SUM(error_4xx + error_5xx) as error_count,
+         MAX(hour) as latest_hour
+       FROM api_metrics_hourly
+       ${where ? where + ' AND agent_id IS NOT NULL' : 'WHERE agent_id IS NOT NULL'}
+       GROUP BY agent_id, endpoint, method
+       HAVING error_count >= 3
+       ORDER BY error_count DESC
+       LIMIT 20`,
+      ...params,
+    );
+
+    json(res, 200, withTimestamp({
+      summary: {
+        total_requests: summary.total_requests,
+        success_count: summary.success_count,
+        error_4xx: summary.error_4xx,
+        error_5xx: summary.error_5xx,
+        error_rate_4xx: summary.total_requests > 0 ? summary.error_4xx / summary.total_requests : 0,
+        error_rate_5xx: summary.total_requests > 0 ? summary.error_5xx / summary.total_requests : 0,
+        avg_latency_ms: Math.round(summary.avg_latency * 100) / 100,
+      },
+      hourly: hourlyBreakdown,
+      endpoints: endpointBreakdown,
+      agents: agentBreakdown,
+      top_errors: topErrors,
+      repeat_offenders: repeatOffenders,
+      filters: {
+        endpoint: endpointFilter,
+        agent: agentFilter,
+        from: fromParam,
+        to: toParam,
+        hours,
+      },
+    }));
+    return true;
+  }
+
+  return false;
+}

--- a/daemon/src/automation/tasks/api-metrics-aggregation.ts
+++ b/daemon/src/automation/tasks/api-metrics-aggregation.ts
@@ -1,0 +1,165 @@
+/**
+ * API Metrics Aggregation — hourly rollup and raw log purge.
+ *
+ * Runs hourly (configured in scheduler):
+ * 1. Aggregates api_request_logs into api_metrics_hourly for the previous hour.
+ * 2. Purges raw logs older than 24 hours.
+ *
+ * Aggregation groups by (hour, endpoint, method, agent_id) and computes:
+ * - total_requests, success_count (2xx/3xx), error_4xx, error_5xx
+ * - avg_latency_ms, p95_latency_ms (approximated via sorted list)
+ */
+
+import { query, exec, getDatabase } from '../../core/db.js';
+import { createLogger } from '../../core/logger.js';
+import type { Scheduler } from '../scheduler.js';
+
+const log = createLogger('api-metrics-aggregation');
+
+interface AggGroup {
+  hour: string;
+  endpoint: string;
+  method: string;
+  agent_id: string | null;
+  total_requests: number;
+  success_count: number;
+  error_4xx: number;
+  error_5xx: number;
+  avg_latency_ms: number;
+}
+
+interface LatencyRow {
+  latency_ms: number;
+}
+
+/**
+ * Aggregate raw request logs for a given hour into hourly metrics.
+ */
+function aggregateHour(hour: string): number {
+  // Find all distinct (endpoint, method, agent_id) groups for this hour
+  const groups = query<AggGroup>(
+    `SELECT
+       strftime('%Y-%m-%d %H:00', timestamp) as hour,
+       path as endpoint,
+       method,
+       agent_id,
+       COUNT(*) as total_requests,
+       SUM(CASE WHEN status_code < 400 THEN 1 ELSE 0 END) as success_count,
+       SUM(CASE WHEN status_code >= 400 AND status_code < 500 THEN 1 ELSE 0 END) as error_4xx,
+       SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END) as error_5xx,
+       AVG(latency_ms) as avg_latency_ms
+     FROM api_request_logs
+     WHERE strftime('%Y-%m-%d %H:00', timestamp) = ?
+     GROUP BY path, method, agent_id`,
+    hour,
+  );
+
+  if (groups.length === 0) return 0;
+
+  const db = getDatabase();
+  const upsert = db.prepare(
+    `INSERT INTO api_metrics_hourly (hour, endpoint, method, total_requests, success_count, error_4xx, error_5xx, avg_latency_ms, p95_latency_ms, agent_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (hour, endpoint, method, COALESCE(agent_id, ''))
+     DO UPDATE SET
+       total_requests = excluded.total_requests,
+       success_count = excluded.success_count,
+       error_4xx = excluded.error_4xx,
+       error_5xx = excluded.error_5xx,
+       avg_latency_ms = excluded.avg_latency_ms,
+       p95_latency_ms = excluded.p95_latency_ms`,
+  );
+
+  let rowsInserted = 0;
+  for (const group of groups) {
+    // Calculate p95 latency for this group
+    const latencies = query<LatencyRow>(
+      `SELECT latency_ms FROM api_request_logs
+       WHERE strftime('%Y-%m-%d %H:00', timestamp) = ?
+         AND path = ? AND method = ?
+         AND (agent_id = ? OR (agent_id IS NULL AND ? IS NULL))
+       ORDER BY latency_ms ASC`,
+      hour,
+      group.endpoint,
+      group.method,
+      group.agent_id,
+      group.agent_id,
+    );
+
+    let p95 = 0;
+    if (latencies.length > 0) {
+      const idx = Math.ceil(latencies.length * 0.95) - 1;
+      p95 = latencies[Math.max(0, idx)]!.latency_ms;
+    }
+
+    upsert.run(
+      group.hour,
+      group.endpoint,
+      group.method,
+      group.total_requests,
+      group.success_count,
+      group.error_4xx,
+      group.error_5xx,
+      Math.round(group.avg_latency_ms * 100) / 100,
+      Math.round(p95 * 100) / 100,
+      group.agent_id,
+    );
+    rowsInserted++;
+  }
+
+  return rowsInserted;
+}
+
+/**
+ * Purge raw request logs older than 24 hours.
+ */
+function purgeOldLogs(): number {
+  const result = exec(
+    `DELETE FROM api_request_logs WHERE timestamp < datetime('now', '-24 hours')`,
+  );
+  return result.changes;
+}
+
+/**
+ * Main aggregation logic.
+ */
+async function run(): Promise<void> {
+  const startMs = Date.now();
+
+  // Find distinct hours in raw logs that haven't been aggregated yet
+  // Focus on the previous hour to ensure we get complete data
+  const hours = query<{ hour: string }>(
+    `SELECT DISTINCT strftime('%Y-%m-%d %H:00', timestamp) as hour
+     FROM api_request_logs
+     WHERE strftime('%Y-%m-%d %H:00', timestamp) < strftime('%Y-%m-%d %H:00', 'now')
+     ORDER BY hour`,
+  );
+
+  let totalRows = 0;
+  for (const { hour } of hours) {
+    totalRows += aggregateHour(hour);
+  }
+
+  const purged = purgeOldLogs();
+  const durationMs = Date.now() - startMs;
+
+  if (totalRows > 0 || purged > 0) {
+    log.info('Metrics aggregation completed', {
+      hoursProcessed: hours.length,
+      groupsUpserted: totalRows,
+      rawLogsPurged: purged,
+      durationMs,
+    });
+  } else {
+    log.debug('Metrics aggregation — nothing to process');
+  }
+}
+
+/**
+ * Register the api-metrics-aggregation task with the scheduler.
+ */
+export function register(scheduler: Scheduler): void {
+  scheduler.registerHandler('api-metrics-aggregation', async () => {
+    await run();
+  });
+}

--- a/daemon/src/automation/tasks/index.ts
+++ b/daemon/src/automation/tasks/index.ts
@@ -18,6 +18,7 @@ import { register as registerOrchestratorIdle } from './orchestrator-idle.js';
 import { register as registerMessageDelivery } from './message-delivery.js';
 import { register as registerCommsHeartbeat } from './comms-heartbeat.js';
 import { register as registerPeerHeartbeat } from './peer-heartbeat.js';
+import { register as registerMetricsAggregation } from './api-metrics-aggregation.js';
 export { loadExternalTasks, type LoadResult } from './external-loader.js';
 
 /**
@@ -35,6 +36,7 @@ export function registerCoreTasks(scheduler: Scheduler): void {
     { name: 'message-delivery', register: registerMessageDelivery },
     { name: 'comms-heartbeat', register: registerCommsHeartbeat },
     { name: 'peer-heartbeat', register: registerPeerHeartbeat },
+    { name: 'api-metrics-aggregation', register: registerMetricsAggregation },
   ];
 
   for (const { name, register } of registrations) {

--- a/daemon/src/core/migrations/012-api-metrics.sql
+++ b/daemon/src/core/migrations/012-api-metrics.sql
@@ -1,0 +1,39 @@
+-- API metrics: request logging and hourly aggregation tables.
+
+CREATE TABLE IF NOT EXISTS api_request_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+  method TEXT NOT NULL,
+  path TEXT NOT NULL,
+  status_code INTEGER NOT NULL,
+  latency_ms REAL NOT NULL,
+  agent_id TEXT,
+  error_fields TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_request_logs_timestamp ON api_request_logs(timestamp);
+CREATE INDEX IF NOT EXISTS idx_api_request_logs_path ON api_request_logs(path);
+CREATE INDEX IF NOT EXISTS idx_api_request_logs_agent_id ON api_request_logs(agent_id);
+CREATE INDEX IF NOT EXISTS idx_api_request_logs_status_code ON api_request_logs(status_code);
+
+CREATE TABLE IF NOT EXISTS api_metrics_hourly (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  hour TEXT NOT NULL,
+  endpoint TEXT NOT NULL,
+  method TEXT NOT NULL,
+  total_requests INTEGER NOT NULL DEFAULT 0,
+  success_count INTEGER NOT NULL DEFAULT 0,
+  error_4xx INTEGER NOT NULL DEFAULT 0,
+  error_5xx INTEGER NOT NULL DEFAULT 0,
+  avg_latency_ms REAL NOT NULL DEFAULT 0,
+  p95_latency_ms REAL NOT NULL DEFAULT 0,
+  agent_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_metrics_hourly_hour ON api_metrics_hourly(hour);
+CREATE INDEX IF NOT EXISTS idx_api_metrics_hourly_endpoint ON api_metrics_hourly(endpoint);
+CREATE INDEX IF NOT EXISTS idx_api_metrics_hourly_agent_id ON api_metrics_hourly(agent_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_metrics_hourly_unique
+  ON api_metrics_hourly(hour, endpoint, method, COALESCE(agent_id, ''));

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -25,6 +25,7 @@ import { handleTimerRoute, initTimers } from './api/timer.js';
 import { handleSelftestRoute } from './api/selftest.js';
 import { handleTaskQueueRoute } from './api/task-queue.js';
 import { handleContactsRoute } from './api/contacts.js';
+import { handleMetricsRoute, logRequest } from './api/metrics.js';
 import {
   getExtension,
   isDegraded,
@@ -141,6 +142,40 @@ function addTimestamp(res: http.ServerResponse): void {
 
 const server = http.createServer((req, res) => {
   const url = new URL(req.url ?? '/', `http://localhost:${config.daemon.port}`);
+  const requestStartMs = Date.now();
+
+  // Capture status code and body field names for metrics logging
+  let capturedStatusCode = 200;
+  let capturedBodyFields: string[] | null = null;
+  const origWriteHead = res.writeHead.bind(res);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res.writeHead = function metricsWriteHead(statusCode: number, ...args: any[]) {
+    capturedStatusCode = statusCode;
+    return origWriteHead(statusCode, ...args);
+  } as typeof res.writeHead;
+
+  // Capture request body field names for 4xx error logging
+  const chunks: Buffer[] = [];
+  req.on('data', (chunk: Buffer) => chunks.push(chunk));
+
+  res.on('finish', () => {
+    const latencyMs = Date.now() - requestStartMs;
+    // Extract body field names only on 4xx for diagnostics
+    if (capturedStatusCode >= 400 && capturedStatusCode < 500 && chunks.length > 0) {
+      try {
+        const body = JSON.parse(Buffer.concat(chunks).toString());
+        if (body && typeof body === 'object') {
+          capturedBodyFields = Object.keys(body);
+        }
+      } catch {
+        // Not JSON — ignore
+      }
+    }
+    // Skip logging /api/metrics itself to avoid feedback loops
+    if (url.pathname !== '/api/metrics') {
+      logRequest(req, capturedStatusCode, latencyMs, capturedBodyFields);
+    }
+  });
 
   addTimestamp(res);
 
@@ -225,6 +260,7 @@ const server = http.createServer((req, res) => {
         () => handleTasksRoute(req, res, url.pathname),
         () => handleConfigRoute(req, res, url.pathname),
         () => handleSelftestRoute(req, res, url.pathname),
+        () => handleMetricsRoute(req, res, url.pathname, url.searchParams),
       ];
       for (const handler of handlers) {
         const handled = await handler();

--- a/kithkit.defaults.yaml
+++ b/kithkit.defaults.yaml
@@ -52,6 +52,12 @@ scheduler:
       config:
         requires_session: true
 
+    - name: api-metrics-aggregation
+      interval: "1h"
+      enabled: true
+      config:
+        requires_session: false
+
 security:
   rate_limits:
     incoming_max_per_minute: 5


### PR DESCRIPTION
## Summary
- **Request logging**: Every HTTP request logged to `api_request_logs` (method, path, status, latency, agent ID from `X-Agent` header, body field names on 4xx errors)
- **Hourly aggregation**: New `api-metrics-aggregation` scheduler task rolls up raw logs into `api_metrics_hourly` every hour, purges raw logs older than 24h
- **Metrics API**: `GET /api/metrics` returns aggregated data sliceable by endpoint, agent, and time range — includes summary stats, hourly breakdown, per-endpoint/agent breakdown, top errors, and repeat-offender detection
- **Dashboard**: Dark-themed standalone HTML page at `/metrics.html` with Chart.js — request volume, error trends, latency, per-agent breakdown, and error tables. Auto-refreshes every 60s.

## Files Changed
| File | Purpose |
|------|---------|
| `daemon/src/core/migrations/012-api-metrics.sql` | New tables: `api_request_logs`, `api_metrics_hourly` |
| `daemon/src/api/metrics.ts` | Request logging (`logRequest()`) + `GET /api/metrics` handler |
| `daemon/src/main.ts` | Hooks `logRequest()` into response lifecycle, adds metrics route |
| `daemon/src/automation/tasks/api-metrics-aggregation.ts` | Hourly aggregation + purge task |
| `daemon/src/automation/tasks/index.ts` | Register aggregation task |
| `kithkit.defaults.yaml` | Default scheduler config for `api-metrics-aggregation` (1h interval) |
| `daemon/public/metrics.html` | Standalone metrics dashboard |

## Design Decisions
- One row per request (lightweight), body field names only (not values) on 4xx
- Agent attribution via `X-Agent` header, fallback to `User-Agent`
- p95 latency calculated from sorted raw logs during aggregation
- Dashboard uses Chart.js from CDN — no build step, no framework
- `/api/metrics` endpoint excluded from self-logging to avoid feedback loops

## Test plan
- [x] TypeScript compiles clean (only pre-existing sdk-bridge error unrelated to this PR)
- [x] All 19 existing tests pass
- [ ] Manual verification: start daemon, make requests, check `/api/metrics` returns data
- [ ] Manual verification: open `/metrics.html` in browser, confirm charts render
- [ ] Verify aggregation task runs and populates `api_metrics_hourly`
- [ ] Verify raw log purge works after 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)