### PR TITLE
fix: orchestrator liveness detection and dead-orch respawn

### DIFF
--- a/daemon/src/__tests__/lifecycle.test.ts
+++ b/daemon/src/__tests__/lifecycle.test.ts
@@ -557,3 +557,49 @@ describe('GET /api/agents/:id/status returns job details (t-137 supplement)', ()
     assert.equal(res.status, 404);
   });
 });
+
+describe('PUT /api/agents/:id updates agent status (#121)', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('updates agent status via PUT', async () => {
+    // Create an agent first
+    const ts = new Date().toISOString();
+    exec(
+      `INSERT INTO agents (id, type, status, created_at, updated_at)
+       VALUES ('orch-put-test', 'orchestrator', 'running', ?, ?)`,
+      ts, ts,
+    );
+
+    const res = await request('PUT', '/api/agents/orch-put-test', { status: 'stopped' });
+    assert.equal(res.status, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.status, 'updated');
+
+    // Verify in DB
+    const agent = getAgentStatus('orch-put-test');
+    assert.equal(agent!.status, 'stopped');
+  });
+
+  it('returns 404 for unknown agent', async () => {
+    const res = await request('PUT', '/api/agents/nonexistent', { status: 'stopped' });
+    assert.equal(res.status, 404);
+  });
+
+  it('updates updated_at timestamp', async () => {
+    const oldTs = new Date(Date.now() - 60_000).toISOString();
+    exec(
+      `INSERT INTO agents (id, type, status, created_at, updated_at)
+       VALUES ('orch-ts-test', 'orchestrator', 'running', ?, ?)`,
+      oldTs, oldTs,
+    );
+
+    await request('PUT', '/api/agents/orch-ts-test', { status: 'stopped' });
+
+    const agent = getAgentStatus('orch-ts-test');
+    assert.ok(
+      new Date(agent!.updated_at).getTime() > new Date(oldTs).getTime(),
+      'updated_at should be newer than original',
+    );
+  });
+});

--- a/daemon/src/__tests__/orchestrator-idle.test.ts
+++ b/daemon/src/__tests__/orchestrator-idle.test.ts
@@ -329,11 +329,12 @@ describe('Orchestrator idle: liveness check', () => {
     cleanupTestEnv(tmpDir);
   });
 
-  it('does nothing when orchestrator is not alive and no nudge pending', async () => {
+  it('does nothing when orchestrator is not alive, no nudge pending, and no pending tasks', async () => {
     _setDepsForTesting({
       isOrchestratorAlive: () => false,
       killOrchestratorSession: () => { throw new Error('should not kill'); },
       injectMessage: () => { throw new Error('should not inject'); },
+      spawnOrchestratorSession: () => { throw new Error('should not spawn — no pending tasks'); },
       cleanupSessionDirs: () => 0,
     });
 
@@ -420,5 +421,125 @@ describe('Orchestrator idle: liveness check', () => {
     assert.ok(injectedText.includes('pending task'), 'should inject task notification not shutdown');
     assert.ok(injectedText.includes('Fix the login bug'), 'should include task title');
     assert.ok(!injectedText.includes('Shutdown requested'), 'should NOT inject shutdown prompt');
+  });
+});
+
+describe('Orchestrator idle: respawn for pending tasks when dead (#121)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = setupTestEnv();
+  });
+
+  afterEach(() => {
+    cleanupTestEnv(tmpDir);
+  });
+
+  it('spawns fresh orchestrator when dead and pending tasks exist', async () => {
+    let spawnedWithPrompt = '';
+    _setDepsForTesting({
+      isOrchestratorAlive: () => false,
+      killOrchestratorSession: () => false,
+      injectMessage: () => false,
+      spawnOrchestratorSession: (prompt: string) => { spawnedWithPrompt = prompt; return 'orch1'; },
+      cleanupSessionDirs: () => 0,
+    });
+
+    // Insert a pending orchestrator task
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, description, status, priority, created_at, updated_at)
+       VALUES ('respawn-task-1', 'Deploy the widget', 'Deploy widget to prod', 'pending', 0, ?, ?)`,
+      new Date().toISOString(), new Date().toISOString(),
+    );
+
+    await _runForTesting({});
+
+    assert.ok(spawnedWithPrompt.length > 0, 'should have spawned a fresh orchestrator');
+    assert.ok(spawnedWithPrompt.includes('pending task'), 'prompt should mention pending tasks');
+    assert.ok(spawnedWithPrompt.includes('Deploy the widget'), 'prompt should include task title');
+
+    // Agent DB should be updated to running
+    const agents = query<{ status: string }>(
+      "SELECT status FROM agents WHERE id = 'orchestrator'",
+    );
+    assert.equal(agents[0]!.status, 'running', 'agent status should be running after respawn');
+  });
+
+  it('does not spawn when dead and no pending tasks', async () => {
+    _setDepsForTesting({
+      isOrchestratorAlive: () => false,
+      killOrchestratorSession: () => false,
+      injectMessage: () => false,
+      spawnOrchestratorSession: () => { throw new Error('should not spawn — no pending tasks'); },
+      cleanupSessionDirs: () => 0,
+    });
+
+    // No pending tasks — should not spawn
+    await _runForTesting({});
+  });
+
+  it('corrects stale DB status when orchestrator session is gone', async () => {
+    // Set DB status to 'running' even though orch is dead (simulates failed cleanup)
+    update('agents', 'orchestrator', { status: 'running' });
+
+    _setDepsForTesting({
+      isOrchestratorAlive: () => false,
+      killOrchestratorSession: () => false,
+      injectMessage: () => false,
+      spawnOrchestratorSession: () => { throw new Error('should not spawn — no pending tasks'); },
+      cleanupSessionDirs: () => 0,
+    });
+
+    await _runForTesting({});
+
+    // DB status should now be corrected to 'stopped'
+    const agents = query<{ status: string }>(
+      "SELECT status FROM agents WHERE id = 'orchestrator'",
+    );
+    assert.equal(agents[0]!.status, 'stopped', 'stale running status should be corrected to stopped');
+  });
+
+  it('logs session_end activity when correcting stale DB status', async () => {
+    update('agents', 'orchestrator', { status: 'running' });
+
+    _setDepsForTesting({
+      isOrchestratorAlive: () => false,
+      killOrchestratorSession: () => false,
+      injectMessage: () => false,
+      spawnOrchestratorSession: () => { throw new Error('should not spawn'); },
+      cleanupSessionDirs: () => 0,
+    });
+
+    await _runForTesting({});
+
+    const logs = query<{ event_type: string; details: string }>(
+      "SELECT event_type, details FROM agent_activity_log WHERE agent_id = 'orchestrator' AND event_type = 'session_end'",
+    );
+    assert.ok(logs.length > 0, 'should have logged session_end for stale status correction');
+    assert.ok(logs[0]!.details.includes('stale'), `details should mention stale: ${logs[0]!.details}`);
+  });
+
+  it('logs session_start activity after respawn', async () => {
+    _setDepsForTesting({
+      isOrchestratorAlive: () => false,
+      killOrchestratorSession: () => false,
+      injectMessage: () => false,
+      spawnOrchestratorSession: () => 'orch1',
+      cleanupSessionDirs: () => 0,
+    });
+
+    exec(
+      `INSERT INTO orchestrator_tasks (id, title, description, status, priority, created_at, updated_at)
+       VALUES ('respawn-task-2', 'Another task', 'Do something', 'pending', 0, ?, ?)`,
+      new Date().toISOString(), new Date().toISOString(),
+    );
+
+    await _runForTesting({});
+
+    const logs = query<{ event_type: string; details: string }>(
+      "SELECT event_type, details FROM agent_activity_log WHERE agent_id = 'orchestrator' AND event_type = 'session_start'",
+    );
+    assert.ok(logs.length > 0, 'should have logged session_start after respawn');
+    assert.ok(logs[0]!.details.includes('Respawned by idle monitor'), `details: ${logs[0]!.details}`);
   });
 });

--- a/daemon/src/api/agents.ts
+++ b/daemon/src/api/agents.ts
@@ -119,6 +119,25 @@ export async function handleAgentsRoute(
         return true;
       }
 
+      // PUT /api/agents/:id — update agent status (used by orchestrator wrapper cleanup)
+      if (suffix === '' && method === 'PUT') {
+        const body = await parseBody(req);
+        const agent = getAgentStatus(agentId);
+        if (!agent) {
+          json(res, 404, withTimestamp({ error: 'Not found' }));
+          return true;
+        }
+
+        const updates: Record<string, string> = { updated_at: new Date().toISOString() };
+        if (typeof body.status === 'string') {
+          updates.status = body.status as string;
+        }
+
+        update('agents', agentId, updates);
+        json(res, 200, withTimestamp({ status: 'updated', id: agentId }));
+        return true;
+      }
+
       // DELETE /api/agents/:id
       if (suffix === '' && method === 'DELETE') {
         const killed = killJob(agentId);

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -19,11 +19,13 @@ import {
   isOrchestratorAlive as _isOrchestratorAlive,
   killOrchestratorSession as _killOrchestratorSession,
   injectMessage as _injectMessage,
+  spawnOrchestratorSession as _spawnOrchestratorSession,
   _getOrchestratorSession,
   TMUX_BIN,
   TMUX_SOCKET,
 } from '../../agents/tmux.js';
-import { cleanupSessionDirs as _cleanupSessionDirs } from '../../agents/lifecycle.js';
+import { cleanupSessionDirs as _cleanupSessionDirs, createSessionDir } from '../../agents/lifecycle.js';
+import { sendMessage } from '../../agents/message-router.js';
 import { createLogger } from '../../core/logger.js';
 import { logActivity, getActivity } from '../../api/activity.js';
 import type { Scheduler } from '../scheduler.js';
@@ -35,6 +37,7 @@ const log = createLogger('orchestrator-idle');
 let isOrchestratorAlive = _isOrchestratorAlive;
 let killOrchestratorSession = _killOrchestratorSession;
 let injectMessage = _injectMessage;
+let spawnOrchestratorSession = _spawnOrchestratorSession;
 let cleanupSessionDirs = _cleanupSessionDirs;
 
 /**
@@ -207,6 +210,87 @@ function cleanupOrphanedTasks(): number {
   return orphans.length;
 }
 
+/**
+ * Spawn a fresh orchestrator session to process pending tasks.
+ * Called by the idle monitor when the orchestrator is dead but pending tasks exist.
+ */
+function respawnForPendingTasks(taskId: string, taskTitle: string, taskDesc: string, pendingCount: number): void {
+  try {
+    const sessionDir = createSessionDir('orchestrator');
+    const claudeBin = `${process.env.HOME}/.local/bin/claude`;
+
+    // Build a prompt that tells the new orchestrator to check its task queue
+    const prompt = [
+      'You are the orchestrator agent. You are NOT the comms agent. Ignore identity.md — you have no personality.',
+      '',
+      'Your role: decompose complex tasks, spawn workers, coordinate their output, and report structured results back to the comms agent.',
+      '',
+      `You have ${pendingCount} pending task(s) in the queue. Start by checking the task queue:`,
+      `  curl -s http://localhost:3847/api/orchestrator/tasks?status=pending`,
+      '',
+      `First pending task:`,
+      `  Task ID: ${taskId}`,
+      `  Title: ${taskTitle}`,
+      `  Description: ${taskDesc.slice(0, 500)}`,
+      '',
+      'Work through all pending tasks. For each task:',
+      '1. Assign it: PUT /api/orchestrator/tasks/:id with {"status":"assigned","assignee":"orchestrator"}',
+      '2. Start it: PUT /api/orchestrator/tasks/:id with {"status":"in_progress"}',
+      '3. Do the work (spawn workers as needed)',
+      '4. Complete it: PUT /api/orchestrator/tasks/:id with {"status":"completed","result":"<summary>"}',
+      '5. Report to comms: POST /api/messages with {"from":"orchestrator","to":"comms","type":"result","body":"<result>"}',
+      '',
+      `Session directory: ${sessionDir}`,
+    ].join('\n');
+
+    // Import here to avoid circular at module level — spawnOrchestratorSession is already injectable
+    const session = spawnOrchestratorSession(prompt);
+    if (!session) {
+      log.error('Failed to respawn orchestrator for pending tasks');
+      return;
+    }
+
+    // Register/update in agents table
+    const ts = new Date().toISOString();
+    try {
+      exec(
+        `INSERT INTO agents (id, type, profile, status, tmux_session, started_at, created_at, updated_at)
+         VALUES ('orchestrator', 'orchestrator', 'orchestrator', 'running', ?, ?, ?, ?)`,
+        session, ts, ts, ts,
+      );
+    } catch {
+      // Already exists — update
+      update('agents', 'orchestrator', {
+        status: 'running',
+        tmux_session: session,
+        started_at: ts,
+        updated_at: ts,
+      });
+    }
+
+    logActivity({
+      agent_id: 'orchestrator',
+      session_id: session,
+      event_type: 'session_start',
+      details: `Respawned by idle monitor for ${pendingCount} pending task(s): ${taskTitle.slice(0, 100)}`,
+    });
+
+    // Send the task as a message so the wrapper's poll loop can also find it
+    sendMessage({
+      from: 'daemon',
+      to: 'orchestrator',
+      type: 'task',
+      body: JSON.stringify({ task: taskTitle, context: taskDesc, task_id: taskId }),
+    });
+
+    log.info('Orchestrator respawned for pending tasks', { session, pendingCount, taskId });
+  } catch (err) {
+    log.error('Failed to respawn orchestrator', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 const PENDING_TIMEOUT_MS = 5 * 60 * 1000;   // 5 minutes
 const STALE_WORK_NOTES_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -234,9 +318,9 @@ function checkTaskTimeouts(): void {
     }
   }
 
-  // Check in_progress tasks with no recent work_notes updates
-  const activeTaskRows = query<{ id: string; title: string; updated_at: string; work_notes: string | null }>(
-    `SELECT id, title, updated_at, work_notes FROM orchestrator_tasks WHERE status = 'in_progress'`,
+  // Check in_progress tasks with no recent updates
+  const activeTaskRows = query<{ id: string; title: string; updated_at: string }>(
+    `SELECT id, title, updated_at FROM orchestrator_tasks WHERE status = 'in_progress'`,
   );
   for (const task of activeTaskRows) {
     const lastUpdate = new Date(task.updated_at).getTime();
@@ -245,7 +329,6 @@ function checkTaskTimeouts(): void {
         taskId: task.id,
         title: task.title.slice(0, 80),
         lastUpdateMinutes: Math.round((now - lastUpdate) / 60000),
-        hasWorkNotes: !!task.work_notes,
       });
     }
   }
@@ -335,9 +418,46 @@ async function run(config: Record<string, unknown>): Promise<void> {
     return;
   }
 
-  // Not alive and no pending nudge — check for zombie tasks left behind
+  // Not alive and no pending nudge — check for zombie tasks, then respawn if pending work exists
   if (!isOrchestratorAlive()) {
     cleanupZombieTasks();
+
+    // Ensure DB status reflects reality — the wrapper cleanup may have failed to update
+    // (e.g. PUT /api/agents/orchestrator returned 404 before the fix).
+    try {
+      const agentRows = query<{ status: string }>(
+        "SELECT status FROM agents WHERE id = 'orchestrator'",
+      );
+      if (agentRows[0] && agentRows[0].status !== 'stopped' && agentRows[0].status !== 'crashed') {
+        log.warn('Orchestrator tmux session gone but DB status was stale — correcting', {
+          oldStatus: agentRows[0].status,
+        });
+        update('agents', 'orchestrator', {
+          status: 'stopped',
+          updated_at: new Date().toISOString(),
+        });
+        logActivity({
+          agent_id: 'orchestrator',
+          event_type: 'session_end',
+          details: 'Session gone — DB status corrected from stale state by idle monitor',
+        });
+      }
+    } catch {
+      // Non-fatal — the respawn below will handle registration
+    }
+
+    // Check for pending tasks that need a fresh orchestrator
+    const pendingForRespawn = query<{ count: number; id: string; title: string; description: string }>(
+      `SELECT COUNT(*) as count, MIN(id) as id, MIN(title) as title, MIN(description) as description
+       FROM orchestrator_tasks WHERE status = 'pending'`,
+    );
+    const pendingCount = pendingForRespawn[0]?.count ?? 0;
+    if (pendingCount > 0) {
+      log.info('Orchestrator dead but pending tasks exist — spawning fresh orchestrator', { pendingCount });
+      const firstTask = pendingForRespawn[0]!;
+      respawnForPendingTasks(firstTask.id, firstTask.title, firstTask.description ?? firstTask.title, pendingCount);
+    }
+
     return;
   }
 
@@ -529,17 +649,20 @@ export function _setDepsForTesting(deps: {
   isOrchestratorAlive?: () => boolean;
   killOrchestratorSession?: () => boolean;
   injectMessage?: (target: string, text: string) => boolean;
+  spawnOrchestratorSession?: (prompt: string) => string | null;
   cleanupSessionDirs?: (maxAgeDays?: number) => number;
 } | null): void {
   if (deps === null) {
     isOrchestratorAlive = _isOrchestratorAlive;
     killOrchestratorSession = _killOrchestratorSession;
     injectMessage = _injectMessage;
+    spawnOrchestratorSession = _spawnOrchestratorSession;
     cleanupSessionDirs = _cleanupSessionDirs;
     return;
   }
   if (deps.isOrchestratorAlive) isOrchestratorAlive = deps.isOrchestratorAlive;
   if (deps.killOrchestratorSession) killOrchestratorSession = deps.killOrchestratorSession;
   if (deps.injectMessage) injectMessage = deps.injectMessage;
+  if (deps.spawnOrchestratorSession) spawnOrchestratorSession = deps.spawnOrchestratorSession;
   if (deps.cleanupSessionDirs) cleanupSessionDirs = deps.cleanupSessionDirs;
 }


### PR DESCRIPTION
## Summary

Fixes #121: Orchestrator wrapper does not reliably poll task queue for pending tasks.

Three root causes identified and fixed:

- **Missing PUT endpoint**: The wrapper's cleanup trap called `PUT /api/agents/orchestrator` to mark itself stopped on exit, but no PUT handler existed on the agents API. The request silently 404'd, leaving the DB status stale at `running`. Added `PUT /api/agents/:id` endpoint to the agents API.

- **No respawn on dead orch with pending tasks**: The orchestrator-idle monitor detected the orch was dead and cleaned up zombie tasks, but never checked for pending tasks that still needed processing. Now when the idle monitor finds the orch dead with pending tasks in the queue, it spawns a fresh orchestrator session and registers it in the agents table.

- **Stale `work_notes` column reference**: `checkTaskTimeouts()` queried a nonexistent `work_notes` column from `orchestrator_tasks`, causing a runtime SQL error on fresh databases. Removed the stale column reference.

Additionally, the idle monitor now corrects stale DB status when the tmux session is gone but the agents table still says `running`, preventing a class of ghost-orch bugs.

## Changes

| File | Change |
|------|--------|
| `daemon/src/api/agents.ts` | Add `PUT /api/agents/:id` endpoint for status updates |
| `daemon/src/automation/tasks/orchestrator-idle.ts` | Respawn logic, stale status correction, `work_notes` fix |
| `daemon/src/__tests__/orchestrator-idle.test.ts` | 5 new tests for respawn, stale DB correction, activity logging |
| `daemon/src/__tests__/lifecycle.test.ts` | 3 new tests for PUT endpoint |

## Test plan

- [x] `npm run build` passes
- [x] All 19 orchestrator-idle tests pass (including 5 new)
- [x] All 25 tmux tests pass
- [x] All 3 new PUT endpoint tests pass
- [x] 1 pre-existing lifecycle test failure confirmed on `main` (unrelated to this PR)
- [ ] Manual: escalate a task, let the wrapper time out, verify idle monitor respawns


🤖 Generated with [Claude Code](https://claude.com/claude-code)