### PR TITLE
fix: quote curl URLs with query params for zsh glob safety

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -234,6 +234,7 @@ This applies to both comms (before asking the human directly) and orchestrator (
 - Follow project conventions (TypeScript, ESM, Node.js 22+)
 - Write tests for new functionality
 - Keep changes focused on the assigned task
+- Always quote URLs in `curl` commands (single or double quotes). In zsh, unquoted `?` and `&` characters trigger glob expansion and break the command. Example: `curl 'http://localhost:3847/api/messages?agent=X&limit=20'`
 
 ### Communication
 


### PR DESCRIPTION
## Summary

- In zsh, unquoted `?` and `&` characters in curl URLs trigger glob expansion, breaking the command with errors like `zsh: no matches found`
- Audited all skill files (`.claude/skills/**/*.md`), docs (`docs/**/*.md`), and `CLAUDE.md` for unquoted curl URLs with query parameters
- All existing curl examples with query params in `docs/api-reference.md` were already properly quoted with double quotes — no changes needed there
- Added a clear note to `CLAUDE.md` Quality Standards > Code section to always quote curl URLs, with an example

## Files changed

- `.claude/CLAUDE.md` — added curl URL quoting rule to Code quality standards

## Test plan

- [x] Searched all `.claude/skills/**/*.md` files for unquoted curl URLs with `?` or `&` — none found
- [x] Searched `docs/**/*.md` — existing instances already quoted
- [x] Searched `CLAUDE.md` — single curl example has no query params, no change needed
- [x] Added defensive note to prevent future regressions

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)