### PR TITLE
feat: add optional LAN listener for A2A fallback

### DIFF
--- a/daemon/src/core/config.ts
+++ b/daemon/src/core/config.ts
@@ -14,12 +14,19 @@ export interface AgentConfig {
   identity_file?: string;
 }
 
+export interface LanConfig {
+  enabled: boolean;
+  bind_host: string;
+  port: number;
+}
+
 export interface DaemonConfig {
   port: number;
   bind_host?: string;
   log_level: 'debug' | 'info' | 'warn' | 'error';
   log_dir: string;
   log_rotation: { max_size_mb: number; max_files: number };
+  lan?: LanConfig;
 }
 
 export interface SchedulerConfig {

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -370,6 +370,108 @@ server.on('error', (err: NodeJS.ErrnoException) => {
 
 tryListen();
 
+// ── Optional LAN listener (A2A only) ─────────────────────────
+let lanServer: http.Server | null = null;
+
+if (config.daemon.lan?.enabled) {
+  const lanConfig = config.daemon.lan;
+  const lanLog = createLogger('lan');
+
+  lanServer = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', `http://localhost:${lanConfig.port}`);
+    const requestStartMs = Date.now();
+
+    let capturedStatusCode = 200;
+    const origWriteHead = res.writeHead.bind(res);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    res.writeHead = function metricsWriteHead(statusCode: number, ...args: any[]) {
+      capturedStatusCode = statusCode;
+      return origWriteHead(statusCode, ...args);
+    } as typeof res.writeHead;
+
+    res.on('finish', () => {
+      const latencyMs = Date.now() - requestStartMs;
+      logRequest(req, capturedStatusCode, latencyMs, null);
+    });
+
+    addTimestamp(res);
+
+    // CORS preflight for /health
+    if (req.method === 'OPTIONS' && url.pathname === '/health') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        'Access-Control-Max-Age': '86400',
+      });
+      res.end();
+      return;
+    }
+
+    // Health endpoint
+    if (req.method === 'GET' && url.pathname === '/health') {
+      const health = getHealth(VERSION);
+      const ext = getExtension();
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      });
+      res.end(JSON.stringify({
+        ...health,
+        degraded: isDegraded(),
+        extension: ext ? ext.name : null,
+        listener: 'lan',
+      }));
+      return;
+    }
+
+    // A2A routes only — delegate to extension route registry
+    if (url.pathname.startsWith('/agent/')) {
+      const handleLanRoute = async (): Promise<void> => {
+        if (!isDegraded()) {
+          const routeHandled = await matchRoute(req, res, url.pathname, url.searchParams);
+          if (routeHandled) return;
+        }
+
+        // Extension direct onRoute fallback
+        const ext = getExtension();
+        if (ext?.onRoute && !isDegraded()) {
+          const handled = await ext.onRoute(req, res, url.pathname, url.searchParams);
+          if (handled) return;
+        }
+
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Not found', timestamp: new Date().toISOString() }));
+      };
+
+      handleLanRoute().catch((err) => {
+        lanLog.error('LAN request error', { path: url.pathname, error: String(err) });
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Internal server error', timestamp: new Date().toISOString() }));
+        }
+      });
+      return;
+    }
+
+    // Block everything else
+    res.writeHead(403, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      error: 'LAN listener only serves A2A endpoints',
+      timestamp: new Date().toISOString(),
+    }));
+  });
+
+  lanServer.on('error', (err: NodeJS.ErrnoException) => {
+    lanLog.error(`LAN server error: ${err.message}`);
+    // Don't exit the process — LAN listener is optional
+  });
+
+  lanServer.listen(lanConfig.port, lanConfig.bind_host, () => {
+    lanLog.info(`LAN server listening on ${lanConfig.bind_host}:${lanConfig.port} (A2A routes only)`);
+  });
+}
+
 // ── Graceful shutdown ────────────────────────────────────────
 
 async function shutdown(signal: string): Promise<void> {
@@ -386,6 +488,11 @@ async function shutdown(signal: string): Promise<void> {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+
+  if (lanServer) {
+    lanServer.close();
+    log.info('LAN server stopped');
   }
 
   configWatcher.stop();

--- a/kithkit.defaults.yaml
+++ b/kithkit.defaults.yaml
@@ -9,6 +9,10 @@ daemon:
   port: 3847
   log_level: info
   log_dir: logs
+  lan:
+    enabled: false
+    bind_host: "0.0.0.0"
+    port: 3848
   log_rotation:
     max_size_mb: 10
     max_files: 5


### PR DESCRIPTION
## Summary
- Adds `daemon.lan` config section (disabled by default) that starts a second HTTP server on a LAN-accessible address
- Only `/agent/*` and `/health` routes are exposed on the LAN listener — all other API endpoints remain localhost-only, preserving the existing security model
- LAN listener is independent of the main server — if it fails to bind, the daemon continues normally

## Config
```yaml
daemon:
  lan:
    enabled: true       # default: false
    bind_host: "0.0.0.0"  # default: 0.0.0.0
    port: 3848           # default: 3848
```

## Changes
- `daemon/src/core/config.ts` — Added `LanConfig` interface and optional `lan` field to `DaemonConfig`
- `kithkit.defaults.yaml` — Added `daemon.lan` defaults (disabled)
- `daemon/src/main.ts` — Added optional second HTTP server for LAN A2A routes with graceful shutdown

## Security
- Main API (`/api/*`, state management, agent spawn, etc.) stays on localhost only — no auth changes
- LAN listener only serves `/agent/*` routes which already require Bearer auth via the agent-comms extension
- Non-A2A requests to the LAN listener get 403

## Test plan
- [ ] Verify daemon starts normally with `lan.enabled: false` (default) — no second listener
- [ ] Enable `lan.enabled: true`, verify LAN server starts on port 3848
- [ ] Verify `/health` responds on LAN port
- [ ] Verify `/agent/message` works on LAN port (with Bearer auth)
- [ ] Verify `/api/*` routes return 403 on LAN port
- [ ] Verify graceful shutdown closes both servers

Closes todo #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)