### PR TITLE
fix: pre-buffer request body to prevent parseBody race condition

### DIFF
--- a/daemon/src/api/helpers.ts
+++ b/daemon/src/api/helpers.ts
@@ -24,8 +24,18 @@ const MAX_BODY_SIZE = 1024 * 1024; // 1MB
 
 /**
  * Parse a JSON request body with a 1MB size limit.
+ *
+ * If the body was pre-buffered by the metrics middleware (stored as
+ * req._rawBody), parses synchronously from that buffer instead of
+ * attaching new stream listeners (which would miss already-emitted events).
  */
 export function parseBody(req: http.IncomingMessage): Promise<Record<string, unknown>> {
+  const pre = (req as unknown as Record<string, unknown>)._rawBody;
+  if (pre instanceof Buffer) {
+    if (pre.length === 0) return Promise.resolve({});
+    try { return Promise.resolve(JSON.parse(pre.toString()) as Record<string, unknown>); }
+    catch { return Promise.reject(new Error('Invalid JSON')); }
+  }
   return new Promise((resolve, reject) => {
     let body = '';
     let size = 0;

--- a/daemon/src/extensions/comms/index.ts
+++ b/daemon/src/extensions/comms/index.ts
@@ -211,6 +211,11 @@ export function getHimalayaAdapters(): BmoHimalayaAdapter[] {
 // ── Helpers ──────────────────────────────────────────────────
 
 function readBody(req: http.IncomingMessage): Promise<string> {
+  // Check for pre-buffered body from main.ts metrics middleware
+  const rawBody = (req as unknown as Record<string, unknown>)._rawBody;
+  if (rawBody instanceof Buffer) {
+    return Promise.resolve(rawBody.toString());
+  }
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     req.on('data', (chunk: Buffer) => chunks.push(chunk));

--- a/daemon/src/extensions/index.ts
+++ b/daemon/src/extensions/index.ts
@@ -52,6 +52,11 @@ const log = createLogger('r2-extension');
 // ── Helpers ──────────────────────────────────────────────────
 
 function readBody(req: http.IncomingMessage): Promise<string> {
+  // Check for pre-buffered body from main.ts metrics middleware
+  const rawBody = (req as unknown as Record<string, unknown>)._rawBody;
+  if (rawBody instanceof Buffer) {
+    return Promise.resolve(rawBody.toString());
+  }
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     req.on('data', (chunk: Buffer) => chunks.push(chunk));

--- a/daemon/src/extensions/voice/index.ts
+++ b/daemon/src/extensions/voice/index.ts
@@ -54,6 +54,11 @@ let _enabled = false;
 // ── Body parsers ─────────────────────────────────────────────
 
 function parseBody(req: http.IncomingMessage): Promise<string> {
+  // Check for pre-buffered body from main.ts metrics middleware
+  const rawBody = (req as unknown as Record<string, unknown>)._rawBody;
+  if (rawBody instanceof Buffer) {
+    return Promise.resolve(rawBody.toString());
+  }
   return new Promise((resolve) => {
     let body = '';
     req.on('data', (c: Buffer) => { body += c.toString(); });
@@ -62,6 +67,14 @@ function parseBody(req: http.IncomingMessage): Promise<string> {
 }
 
 function parseRawBody(req: http.IncomingMessage, maxBytes: number): Promise<Buffer> {
+  // Check for pre-buffered body from main.ts metrics middleware
+  const rawBody = (req as unknown as Record<string, unknown>)._rawBody;
+  if (rawBody instanceof Buffer) {
+    if (rawBody.length > maxBytes) {
+      return Promise.reject(new Error('PAYLOAD_TOO_LARGE'));
+    }
+    return Promise.resolve(rawBody);
+  }
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalBytes = 0;

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -144,38 +144,14 @@ const server = http.createServer((req, res) => {
   const url = new URL(req.url ?? '/', `http://localhost:${config.daemon.port}`);
   const requestStartMs = Date.now();
 
-  // Capture status code and body field names for metrics logging
+  // Capture status code for metrics logging
   let capturedStatusCode = 200;
-  let capturedBodyFields: string[] | null = null;
   const origWriteHead = res.writeHead.bind(res);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   res.writeHead = function metricsWriteHead(statusCode: number, ...args: any[]) {
     capturedStatusCode = statusCode;
     return origWriteHead(statusCode, ...args);
   } as typeof res.writeHead;
-
-  // Capture request body field names for 4xx error logging
-  const chunks: Buffer[] = [];
-  req.on('data', (chunk: Buffer) => chunks.push(chunk));
-
-  res.on('finish', () => {
-    const latencyMs = Date.now() - requestStartMs;
-    // Extract body field names only on 4xx for diagnostics
-    if (capturedStatusCode >= 400 && capturedStatusCode < 500 && chunks.length > 0) {
-      try {
-        const body = JSON.parse(Buffer.concat(chunks).toString());
-        if (body && typeof body === 'object') {
-          capturedBodyFields = Object.keys(body);
-        }
-      } catch {
-        // Not JSON — ignore
-      }
-    }
-    // Skip logging /api/metrics itself to avoid feedback loops
-    if (url.pathname !== '/api/metrics') {
-      logRequest(req, capturedStatusCode, latencyMs, capturedBodyFields);
-    }
-  });
 
   addTimestamp(res);
 
@@ -316,8 +292,45 @@ const server = http.createServer((req, res) => {
     res.end(JSON.stringify({ error: 'Not found', timestamp: new Date().toISOString() }));
   };
 
-  handleRoutes().catch((err) => {
-    log.error('Request error', { path: url.pathname, error: String(err) });
+  // Buffer the full request body before dispatching routes.
+  // This ensures parseBody() can read it even for handlers that are checked
+  // later in the loop (after awaits have given the event loop time to flush
+  // the stream through the metrics listener).
+  const bodyChunks: Buffer[] = [];
+  req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
+  req.on('end', () => {
+    const rawBody = Buffer.concat(bodyChunks);
+    (req as unknown as Record<string, unknown>)._rawBody = rawBody;
+
+    // Wire up metrics finish logger now that we have the buffered body
+    res.on('finish', () => {
+      const latencyMs = Date.now() - requestStartMs;
+      let capturedBodyFields: string[] | null = null;
+      if (capturedStatusCode >= 400 && capturedStatusCode < 500 && rawBody.length > 0) {
+        try {
+          const body = JSON.parse(rawBody.toString());
+          if (body && typeof body === 'object') {
+            capturedBodyFields = Object.keys(body as object);
+          }
+        } catch {
+          // Not JSON — ignore
+        }
+      }
+      if (url.pathname !== '/api/metrics') {
+        logRequest(req, capturedStatusCode, latencyMs, capturedBodyFields);
+      }
+    });
+
+    handleRoutes().catch((err) => {
+      log.error('Request error', { path: url.pathname, error: String(err) });
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Internal server error', timestamp: new Date().toISOString() }));
+      }
+    });
+  });
+  req.on('error', (err) => {
+    log.error('Request stream error', { path: url.pathname, error: String(err) });
     if (!res.headersSent) {
       res.writeHead(500, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Internal server error', timestamp: new Date().toISOString() }));


### PR DESCRIPTION
## Summary

- The API metrics middleware (introduced in #123) consumed the request stream via `req.on('data')` before route handlers could read it. By the time `parseBody()` or extension `readBody()` attached their own `data` listeners, the stream had already been drained.
- Fix: buffer the full request body into `req._rawBody` **before** dispatching routes, then all body-reading functions check for this pre-buffered value first.
- Affects all code paths that read request bodies: core `parseBody()`, extension `readBody()`, and voice extension `parseBody()`/`parseRawBody()`.

## Files Changed

| File | Change |
|------|--------|
| `daemon/src/main.ts` | Buffer body in `req.on('data'/'end')` before `handleRoutes()`, move metrics finish logging into buffered callback |
| `daemon/src/api/helpers.ts` | `parseBody()` reads from `_rawBody` buffer if present |
| `daemon/src/extensions/index.ts` | `readBody()` reads from `_rawBody` buffer if present |
| `daemon/src/extensions/comms/index.ts` | `readBody()` reads from `_rawBody` buffer if present |
| `daemon/src/extensions/voice/index.ts` | `parseBody()` and `parseRawBody()` read from `_rawBody` buffer if present |

## Root Cause

The metrics middleware attached a `req.on('data')` listener at the top of the request handler to capture body field names for 4xx error diagnostics. Node.js `IncomingMessage` is a `Readable` stream — once data events fire, they're gone. Any handler that attached listeners later (after an `await` boundary) would receive an already-drained stream and hang forever waiting for `end`.

## Test Plan

- [x] `npm run build` passes
- [ ] Manual test: `POST /api/todos` with JSON body — should parse correctly
- [ ] Manual test: verify metrics still log body field names on 4xx responses
- [ ] Verify voice extension audio upload still works with `parseRawBody()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)