### PR TITLE
fix: remove deprecated CC4Me auto-inject references

### DIFF
--- a/.claude/hooks/set-channel.sh
+++ b/.claude/hooks/set-channel.sh
@@ -29,7 +29,6 @@ elif [[ "$PROMPT" == "[Telegram"* ]] || [[ "$PROMPT" == "[3rdParty][Telegram"* ]
     echo "telegram" > "$CHANNEL_FILE"
   fi
 elif [[ "$PROMPT" == "Session cleared"* ]] || \
-     [[ "$PROMPT" == "Session auto-started"* ]] || \
      [[ "$PROMPT" == "/save-state"* ]] || \
      [[ "$PROMPT" == "/clear"* ]] || \
      [[ "$PROMPT" == "/restart"* ]] || \


### PR DESCRIPTION
## Summary

- **Remove `CC4ME_QUIET_START` comment** from `.claude/hooks/session-start.sh` (line 12). This referenced a suppression env var for the auto-resume injection block, which was already removed. The comment was orphaned.
- **Remove `"Session auto-started"` guard** from `.claude/hooks/set-channel.sh` (line 32). The auto-inject block that produced `"Session auto-started..."` prompts via tmux send-keys no longer exists, so this channel guard condition could never match.

Both changes are safe to remove — they reference code paths that no longer exist. No behavioral change.

## Test plan

- [ ] Verify `session-start.sh` still runs cleanly on startup/resume/clear/compact
- [ ] Verify `set-channel.sh` correctly preserves channel on remaining system prompts (`Session cleared`, `/save-state`, `/clear`, `/restart`)
- [ ] Confirm no other files reference `CC4ME_QUIET_START` or `"Session auto-started"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)