### PR TITLE
feat: upgrade session-start hook to v4

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -161,10 +161,14 @@ if [ "$DAEMON_RUNNING" = "true" ]; then
   fi
 
   # Query daemon memory API (hybrid search for best results)
-  MEMORY_CONTEXT=$(curl -s --connect-timeout 2 --max-time 5 \
+  MEMORY_CONTEXT=$(echo "$SEARCH_QUERY" | python3 -c "
+import sys, json
+q = sys.stdin.read().strip()
+print(json.dumps({'mode':'hybrid','query':q,'limit':10}))
+" 2>/dev/null | curl -s --connect-timeout 2 --max-time 5 \
     -X POST "http://localhost:${DAEMON_PORT}/api/memory/search" \
     -H 'Content-Type: application/json' \
-    -d "{\"mode\":\"hybrid\",\"query\":\"$SEARCH_QUERY\",\"limit\":10}" 2>/dev/null | python3 -c "
+    -d @- 2>/dev/null | python3 -c "
 import sys, json
 try:
     data = json.load(sys.stdin)


### PR DESCRIPTION
## Summary

Upgrades `.claude/hooks/session-start.sh` from v3 to v4 with smarter session scoping and memory-aware context loading.

### Key Changes

- **Comms-agent gate**: hook now exits early for non-comms sessions (workers, orchestrator). SDK workers spawned by the daemon run outside tmux and are excluded cleanly — no spurious output, no prompt injection into the wrong session.
- **Smart memory loading**: on startup, queries the daemon's memory API (`POST /api/memory/search`) with keywords extracted from saved state, and injects the top 10 relevant memories into context.
- **Config-driven daemon port**: reads port from `kithkit.config.yaml` (`daemon.port`) instead of hardcoding 3847.
- **Env var rename**: `CC4ME_QUIET_START` → `KITHKIT_QUIET_START` (removes the old CC4Me branding).
- **Clearer auto-resume prompts**: startup and clear/compact prompts now give more explicit instructions about checking next steps and pending todos.

## Test plan

- [ ] Start a comms session in the configured tmux session — hook should run fully and inject context
- [ ] Start a worker or orchestrator session — hook should exit 0 immediately with no output
- [ ] Set `KITHKIT_QUIET_START=1` and restart — auto-resume prompt should be suppressed
- [ ] Confirm daemon port is read from config (test with a non-default port)
- [ ] Confirm memory section appears in context when daemon is running with stored memories

🤖 Generated with [Claude Code](https://claude.com/claude-code)