### PR TITLE
feat: telegram sendToGroup and voice TTS fixes

### DIFF
--- a/daemon/src/extensions/comms/adapters/telegram.ts
+++ b/daemon/src/extensions/comms/adapters/telegram.ts
@@ -797,6 +797,22 @@ export class BmoTelegramAdapter implements ChannelAdapter {
   async sendDirect(text: string, chatId?: string): Promise<boolean> {
     return telegramSend(text, chatId);
   }
+
+  /**
+   * Send a message to the configured home group chat.
+   * Group chat ID is read from channels.telegram.home_group_chat_id in config.
+   * Returns false if no group chat ID is configured.
+   */
+  async sendToGroup(text: string): Promise<boolean> {
+    const rawConfig = loadConfig() as unknown as Record<string, unknown>;
+    const groupChatId = ((rawConfig.channels as Record<string, Record<string, unknown>> | undefined)
+      ?.telegram?.home_group_chat_id) as string | undefined;
+    if (!groupChatId) {
+      log.warn('sendToGroup: channels.telegram.home_group_chat_id not configured');
+      return false;
+    }
+    return telegramSend(text, groupChatId);
+  }
 }
 
 /**

--- a/daemon/src/extensions/voice/index.ts
+++ b/daemon/src/extensions/voice/index.ts
@@ -110,7 +110,7 @@ function getClientIp(req: http.IncomingMessage): string {
 function checkVoiceEnabled(res: http.ServerResponse): boolean {
   if (!_enabled) {
     res.writeHead(503, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Voice is not enabled' }));
+    res.end(JSON.stringify({ error: 'Voice subsystem is disabled' }));
     return false;
   }
   return true;

--- a/daemon/src/extensions/voice/tts.ts
+++ b/daemon/src/extensions/voice/tts.ts
@@ -98,6 +98,17 @@ export function startWorker(): Promise<void> {
 
     startupResolve = resolve;
 
+    // Handle spawn errors (e.g., ENOENT when python venv doesn't exist)
+    worker.on('error', (err) => {
+      log.error('TTS worker spawn error', { error: err.message });
+      workerReady = false;
+      worker = null;
+      if (startupResolve) {
+        startupResolve = null;
+        reject(err);
+      }
+    });
+
     // Watch stdout for READY signal
     worker.stdout?.on('data', (data: Buffer) => {
       const lines = data.toString().split('\n');


### PR DESCRIPTION
## Summary

- **Telegram sendToGroup()**: Add `sendToGroup()` method to the Telegram adapter that reads `channels.telegram.home_group_chat_id` from config, enabling message delivery to the home group chat without passing the chat ID manually each time
- **metrics-push scheduled task**: Add new `metrics-push.ts` task that runs hourly to push API metrics from the local `api_metrics_hourly` table to BMO's dashboard ingest endpoint, with duplicate-push prevention via config-tracked last-pushed hour
- **Task index registration**: Register the new `metrics-push` task in the core task index so the scheduler picks it up
- **Voice extension fix**: Update error message in voice `index.ts` disabled check for clarity ("Voice subsystem is disabled")
- **TTS spawn error handling**: Add `worker.on('error')` handler in `tts.ts` to catch spawn failures (e.g., missing Python venv), properly clean up state, and reject the startup promise instead of hanging

## Test Plan

- [ ] Verify `sendToGroup()` sends to the configured group chat ID when `channels.telegram.home_group_chat_id` is set in config
- [ ] Verify `sendToGroup()` returns `false` and logs a warning when no group chat ID is configured
- [ ] Confirm `metrics-push` task registers without errors on daemon startup
- [ ] Confirm metrics-push correctly queries unpushed hourly rows and POSTs them to BMO's ingest endpoint
- [ ] Confirm metrics-push tracks last-pushed hour in the config table to avoid duplicate pushes
- [ ] Verify TTS worker spawn error is caught and the startup promise rejects cleanly (e.g., when Python venv is missing)
- [ ] Verify voice disabled endpoint returns updated error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)