### PR TITLE
fix: exclude notify-instances.yml from instance sync

### DIFF
--- a/.kithkit-private
+++ b/.kithkit-private
@@ -6,6 +6,7 @@
 
 # Instance configuration
 kithkit.config.yaml
+.github/workflows/notify-instances.yml
 identity.md
 .claude/settings.local.json
 


### PR DESCRIPTION
## Summary
This workflow should only run on the public repo to dispatch notifications to private instance repos. Syncing it to private repos causes circular dispatches and auth token errors.

- Adds `.github/workflows/notify-instances.yml` to `.kithkit-private` exclusion list
- Matches the same exclusion already added to instance repos (e.g., KKit-Skippy commit fadcfe6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)