### PR TITLE
feat: deliver-once notifications

### DIFF
--- a/daemon/src/api/messages.ts
+++ b/daemon/src/api/messages.ts
@@ -1,10 +1,11 @@
 /**
  * Messages API — HTTP endpoints for inter-agent messaging.
  *
- * POST /api/messages          — Send a message between agents
- * GET  /api/messages          — Get message history (filter by agent, type)
- * PUT  /api/messages/:id/read — Mark a single message as read
- * PUT  /api/messages/read-all — Mark all messages for an agent as read
+ * POST /api/messages              — Send a message between agents
+ * GET  /api/messages              — Get message history (filter by agent, type)
+ * GET  /api/messages/unread-summary — Unread count per agent
+ * PUT  /api/messages/:id/read     — Mark a single message as read
+ * PUT  /api/messages/read-all     — Mark all messages for an agent as read
  */
 
 import type http from 'node:http';
@@ -18,6 +19,7 @@ import {
   WorkerRestrictionError,
 } from '../agents/message-router.js';
 import type { MessageType } from '../agents/message-router.js';
+import { query } from '../core/db.js';
 import { json, withTimestamp, parseBody } from './helpers.js';
 
 const VALID_MESSAGE_TYPES: readonly string[] = ['text', 'task', 'result', 'error', 'status'];
@@ -89,6 +91,19 @@ export async function handleMessagesRoute(
         }
         throw err;
       }
+      return true;
+    }
+
+    // GET /api/messages/unread-summary — unread count per agent
+    if (pathname === '/api/messages/unread-summary' && method === 'GET') {
+      const rows = query<{ to_agent: string; unread_count: number }>(
+        `SELECT to_agent, COUNT(*) as unread_count FROM messages
+         WHERE read_at IS NULL
+           AND processed_at IS NOT NULL
+         GROUP BY to_agent
+         ORDER BY to_agent ASC`,
+      );
+      json(res, 200, withTimestamp({ data: rows }));
       return true;
     }
 

--- a/daemon/src/automation/tasks/comms-heartbeat.ts
+++ b/daemon/src/automation/tasks/comms-heartbeat.ts
@@ -1,25 +1,24 @@
 /**
- * Comms Heartbeat — nudges the comms agent when there is pending work.
+ * Comms Heartbeat — nudges the comms agent when workers finish.
  *
  * Every 60 seconds:
  * 1. Check for completed or failed worker agents not yet acknowledged.
- * 2. Check for unread messages addressed to comms.
- * 3. If EITHER has results, inject a brief nudge into the comms tmux session:
- *    "[heartbeat] 2 workers completed, 1 unread message — check in"
- * 4. Mark notified workers as acknowledged so they don't re-trigger.
- * 5. If nothing pending, do nothing (stays silent).
+ * 2. If any found, inject a brief nudge into the comms tmux session:
+ *    "[heartbeat] 2 workers finished — check in"
+ * 3. Mark notified workers as acknowledged so they don't re-trigger.
+ * 4. If nothing pending, do nothing (stays silent).
+ *
+ * Unread message nudging has been removed — message-delivery handles
+ * deliver-once notifications directly.
  */
 
 import { query, exec } from '../../core/db.js';
-import { injectMessage, listSessions, _getCommsSession, getOrchestratorState } from '../../agents/tmux.js';
-import { getLastNotificationTime } from './message-delivery.js';
+import { injectMessage, listSessions, _getCommsSession } from '../../agents/tmux.js';
 import { createLogger } from '../../core/logger.js';
 import type { Scheduler } from '../scheduler.js';
 
 const log = createLogger('comms-heartbeat');
 
-/** Skip heartbeat unread-message nudge if message-delivery notified within this window. */
-const DEDUP_WINDOW_MS = 60_000;
 
 interface AgentRow {
   id: string;
@@ -27,9 +26,6 @@ interface AgentRow {
   acknowledged_at: string | null;
 }
 
-interface MessageCount {
-  count: number;
-}
 
 /**
  * Check whether the comms session (comms1) is alive.
@@ -53,28 +49,6 @@ function getPendingWorkers(): AgentRow[] {
 }
 
 /**
- * Count unread messages addressed to comms.
- *
- * Condition: read_at IS NULL AND processed_at IS NOT NULL
- *   - processed_at IS NOT NULL: message has been delivered to the target session
- *     (set by message-delivery task on successful injection).
- *   - read_at IS NULL: message has not been acknowledged/read by the agent yet.
- *
- * This intentionally excludes undelivered messages (processed_at IS NULL) because
- * those are handled by the message-delivery task, not the heartbeat. The heartbeat
- * only nudges about messages that were delivered but haven't been acted on yet.
- */
-function getUnreadMessageCount(): number {
-  const result = query<MessageCount>(
-    `SELECT COUNT(*) as count FROM messages
-     WHERE to_agent = 'comms'
-       AND read_at IS NULL
-       AND processed_at IS NOT NULL`,
-  );
-  return result[0]?.count ?? 0;
-}
-
-/**
  * Mark a list of worker agent rows as acknowledged.
  */
 function acknowledgeWorkers(ids: string[]): void {
@@ -90,17 +64,10 @@ function acknowledgeWorkers(ids: string[]): void {
 }
 
 /**
- * Build the nudge text from pending worker and message counts.
+ * Build the nudge text from pending worker count.
  */
-function buildNudge(workerCount: number, unreadCount: number): string {
-  const parts: string[] = [];
-  if (workerCount > 0) {
-    parts.push(`${workerCount} worker${workerCount === 1 ? '' : 's'} finished`);
-  }
-  if (unreadCount > 0) {
-    parts.push(`${unreadCount} unread message${unreadCount === 1 ? '' : 's'}`);
-  }
-  return `[heartbeat] ${parts.join(', ')} — check in`;
+function buildNudge(workerCount: number): string {
+  return `[heartbeat] ${workerCount} worker${workerCount === 1 ? '' : 's'} finished — check in`;
 }
 
 /**
@@ -114,29 +81,19 @@ async function run(): Promise<void> {
 
   const pendingWorkers = getPendingWorkers();
 
-  // Skip unread-message nudge if message-delivery already notified comms recently.
-  // This prevents the agent from receiving both a real-time notification and a
-  // heartbeat nudge for the same unread messages (kithkit #30).
-  const lastMessageNotification = getLastNotificationTime('comms');
-  const recentlyNotified = (Date.now() - lastMessageNotification) < DEDUP_WINDOW_MS;
-  const unreadCount = recentlyNotified ? 0 : getUnreadMessageCount();
-
-  if (pendingWorkers.length === 0 && unreadCount === 0) {
+  if (pendingWorkers.length === 0) {
     log.debug('Nothing pending — heartbeat silent');
     return;
   }
 
-  const nudge = buildNudge(pendingWorkers.length, unreadCount);
+  const nudge = buildNudge(pendingWorkers.length);
   const injected = injectMessage('comms', nudge);
 
   if (injected) {
     // Acknowledge the workers we just notified about
     const ids = pendingWorkers.map(w => w.id);
     acknowledgeWorkers(ids);
-    log.info('Heartbeat nudge sent', {
-      workers: pendingWorkers.length,
-      unread: unreadCount,
-    });
+    log.info('Heartbeat nudge sent', { workers: pendingWorkers.length });
   } else {
     log.warn('Heartbeat nudge injection failed — will retry next tick');
   }

--- a/daemon/src/automation/tasks/message-delivery.ts
+++ b/daemon/src/automation/tasks/message-delivery.ts
@@ -1,14 +1,13 @@
 /**
- * Message Delivery — content delivery for inter-agent messages.
+ * Message Delivery — deliver-once content delivery for inter-agent messages.
  *
  * 1. Messages arrive via POST /api/messages → stored as undelivered (processed_at IS NULL)
  * 2. This task runs on a short interval, pulls undelivered messages for persistent agents
  * 3. Injects the FULL MESSAGE CONTENT into the target tmux session
- * 4. Marks as delivered AND read (processed_at + read_at set) on successful injection
+ * 4. Marks as delivered (processed_at + read_at + notified_at set) — no re-pinging
  * 5. Expires undelivered messages after MAX_RETRIES failed injection attempts
  *
- * Because read_at is set on delivery, neither the re-ping phase nor comms-heartbeat
- * will follow up — the agent already has the content in their session.
+ * Deliver-once: each message is notified exactly once. No re-ping phase.
  */
 
 import { query, exec, update } from '../../core/db.js';
@@ -24,8 +23,6 @@ const log = createLogger('message-delivery');
 /** Max delivery attempts before marking a message as expired. */
 const MAX_RETRIES = 3;
 
-/** Re-ping interval for unread messages (ms). */
-const REPING_INTERVAL_MS = 60_000;
 
 // ── State ────────────────────────────────────────────────────
 
@@ -39,12 +36,6 @@ let _pendingWakeup = false;
  */
 const _retryCounts = new Map<number, number>();
 
-/**
- * Tracks when we last pinged about an unread message.
- * Prevents spamming tmux faster than REPING_INTERVAL_MS.
- * Also persisted in DB metadata.last_notified_at so it survives daemon restarts.
- */
-const _lastPingTime = new Map<number, number>();
 
 /**
  * Tracks the last time we successfully injected a notification ping into
@@ -211,7 +202,7 @@ async function deliverNewMessages(liveSessions: Set<string>): Promise<{ delivere
         const updatedMeta = JSON.stringify({ ...existingMeta, last_notified_at: now });
         // Set both processed_at AND read_at — the agent already has the content
         // in their session, so no follow-up notification is needed.
-        exec('UPDATE messages SET processed_at = ?, read_at = ?, metadata = ? WHERE id = ?', now, now, updatedMeta, msg.id);
+        exec('UPDATE messages SET processed_at = ?, read_at = ?, notified_at = ?, metadata = ? WHERE id = ?', now, now, now, updatedMeta, msg.id);
         _retryCounts.delete(msg.id);
         delivered++;
       }
@@ -236,75 +227,6 @@ async function deliverNewMessages(liveSessions: Set<string>): Promise<{ delivere
   }
 
   return { delivered, failed, expired };
-}
-
-/**
- * Phase 2: Re-deliver unread messages (processed but read_at still NULL — e.g. injection
- * succeeded on a previous run but read_at wasn't set due to older code path).
- * Re-injects content and sets read_at. Only targets comms (see Phase 1 comment).
- */
-async function repingUnreadMessages(liveSessions: Set<string>): Promise<number> {
-  const unread = query<Message>(
-    `SELECT * FROM messages
-     WHERE processed_at IS NOT NULL
-       AND read_at IS NULL
-       AND to_agent = 'comms'
-     ORDER BY created_at ASC`,
-  );
-
-  if (unread.length === 0) return 0;
-
-  const now = Date.now();
-  const nowIso = new Date().toISOString();
-  let repinged = 0;
-
-  // Group by agent — only messages that are due for a re-ping
-  const byAgent = new Map<string, Message[]>();
-  for (const msg of unread) {
-    // Check if we need to skip expired messages (metadata.expired = true)
-    let meta: Record<string, unknown> = {};
-    if (msg.metadata) {
-      try {
-        meta = JSON.parse(msg.metadata);
-        if (meta.expired) continue;
-      } catch { /* ignore parse errors */ }
-    }
-
-    // Use in-memory lastPingTime if available, otherwise hydrate from DB metadata
-    let lastPing = _lastPingTime.get(msg.id);
-    if (lastPing === undefined && meta.last_notified_at) {
-      lastPing = new Date(meta.last_notified_at as string).getTime();
-      _lastPingTime.set(msg.id, lastPing);
-    }
-    if (lastPing !== undefined && now - lastPing < REPING_INTERVAL_MS) continue;
-
-    const existing = byAgent.get(msg.to_agent) ?? [];
-    existing.push(msg);
-    byAgent.set(msg.to_agent, existing);
-  }
-
-  for (const [agentId, messages] of byAgent) {
-    if (!liveSessions.has(agentId)) continue;
-    if (messages.length === 0) continue;
-
-    const contentText = formatBatchContent(messages);
-    const success = injectMessage(agentId, contentText);
-
-    if (success) {
-      for (const msg of messages) {
-        _lastPingTime.set(msg.id, now);
-        // Mark as read + persist metadata so heartbeat and future re-pings skip this message
-        const existingMeta = msg.metadata ? JSON.parse(msg.metadata) : {};
-        const updatedMeta = JSON.stringify({ ...existingMeta, last_notified_at: nowIso });
-        exec('UPDATE messages SET read_at = ?, metadata = ? WHERE id = ?', nowIso, updatedMeta, msg.id);
-      }
-      _lastAgentNotificationTime.set(agentId, now);
-      repinged += messages.length;
-      log.debug('Re-delivery sent for unread messages', { to: agentId, count: messages.length });
-    }
-  }
-
-  return repinged;
 }
 
 // ── Phase 3: Worker completion notifications ─────────────────
@@ -374,14 +296,11 @@ async function deliverMessages(): Promise<void> {
   // Phase 1: Deliver new messages (inject content, mark processed + read)
   const { delivered, failed, expired } = await deliverNewMessages(liveSessions);
 
-  // Phase 2: Re-ping unread messages
-  const repinged = await repingUnreadMessages(liveSessions);
-
-  // Phase 3: Notify spawning agents of worker completions
+  // Phase 2: Notify spawning agents of worker completions
   const workerNotified = await notifyWorkerCompletions(liveSessions);
 
-  if (delivered > 0 || failed > 0 || expired > 0 || repinged > 0 || workerNotified > 0) {
-    log.info('Delivery cycle complete', { delivered, failed, expired, repinged, workerNotified });
+  if (delivered > 0 || failed > 0 || expired > 0 || workerNotified > 0) {
+    log.info('Delivery cycle complete', { delivered, failed, expired, workerNotified });
   }
 }
 
@@ -402,7 +321,6 @@ export function register(scheduler: Scheduler): void {
 /** @internal Reset retry state for testing */
 export function _resetRetriesForTesting(): void {
   _retryCounts.clear();
-  _lastPingTime.clear();
   _lastAgentNotificationTime.clear();
 }
 

--- a/daemon/src/core/migrations/014-add-notified-at.sql
+++ b/daemon/src/core/migrations/014-add-notified-at.sql
@@ -1,0 +1,6 @@
+-- Add notified_at to messages table for deliver-once notification tracking.
+-- When a notification ping is injected into tmux, notified_at is set.
+-- No re-pinging — each message is notified exactly once.
+
+ALTER TABLE messages ADD COLUMN notified_at TEXT;
+CREATE INDEX idx_messages_notified_at ON messages(notified_at);

--- a/daemon/src/extensions/comms/network/sdk-bridge.ts
+++ b/daemon/src/extensions/comms/network/sdk-bridge.ts
@@ -65,7 +65,7 @@ export async function initNetworkSDK(config: Record<string, unknown>): Promise<b
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let CC4MeNetworkClass: any;
     try {
-      // @ts-expect-error — kithkit-a2a-client is a local dev module, resolved at runtime
+      // @ts-ignore — kithkit-a2a-client is a local dev module, resolved at runtime
       const sdk = await import('kithkit-a2a-client');
       CC4MeNetworkClass = sdk.A2ANetwork;
     } catch {


### PR DESCRIPTION
## Summary
- Delete `repingUnreadMessages()` from message-delivery scheduler task — each message is notified exactly once
- Remove unread message count + nudge from comms-heartbeat (now only nudges about finished workers)
- Add `notified_at` column to messages table (migration 014)
- Add `GET /api/messages/unread-summary` endpoint — single SQL query returning unread count per agent

## Context
Part of Orch v2 Phase 2. Eliminates the re-ping nag storm class of bugs by removing re-ping entirely.

## Test plan
- [ ] Verify messages are delivered once and `notified_at` is set
- [ ] Verify `GET /api/messages/unread-summary` returns correct counts
- [ ] Verify comms-heartbeat only reports worker completions, not unread messages
- [ ] Verify migration 014 applies cleanly on fresh and existing DBs

🤖 Generated with [Claude Code](https://claude.com/claude-code)