### PR TITLE
feat: direct message injection — set notified_at

### DIFF
--- a/daemon/src/agents/message-router.ts
+++ b/daemon/src/agents/message-router.ts
@@ -169,12 +169,12 @@ export function sendMessage(req: SendMessageRequest): { messageId: number; deliv
       if (req.direct) {
         const injected = tmuxInjector(req.to, req.body);
         if (injected) {
-          // Mark as processed AND read — the full content was already displayed
-          // in the tmux session, so no follow-up notification is needed.
+          // Mark as processed, read, AND notified — the full content was already
+          // displayed in the tmux session. No follow-up notification needed.
           const now = new Date().toISOString();
           exec(
-            'UPDATE messages SET processed_at = ?, read_at = ? WHERE id = ?',
-            now, now, message.id,
+            'UPDATE messages SET processed_at = ?, read_at = ?, notified_at = ? WHERE id = ?',
+            now, now, now, message.id,
           );
           // Tell the heartbeat dedup that comms was just notified, so it
           // doesn't fire a redundant "[heartbeat] N unread messages" nudge.


### PR DESCRIPTION
## Summary
- Set `notified_at` alongside `processed_at` and `read_at` when `direct:true` injection succeeds
- Add `notified_at` column to messages table (migration 014)

## Context
Part of Orch v2 Phase 3. The `direct:true` flag was already implemented. This change adds the `notified_at` tracking column and updates the injection path to set it, completing the deliver-once notification chain.

**Note:** This branch includes the same `notified_at` migration as the deliver-once PR. Whichever merges first provides the column; the second merge will have a trivial conflict on the migration number.

## Test plan
- [ ] Send a message with `direct:true` and verify `notified_at` is set
- [ ] Verify fallback to scheduler when session is dead
- [ ] Verify migration applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)