### PR TITLE
fix: SDK bridge type cleanup

### DIFF
--- a/daemon/src/extensions/comms/network/api.ts
+++ b/daemon/src/extensions/comms/network/api.ts
@@ -54,7 +54,7 @@ export async function handleNetworkRoute(
         return true;
       }
       const result = await network.requestContact(body.username);
-      json(res, 200, withTimestamp(result as Record<string, unknown>));
+      json(res, 200, withTimestamp(result as unknown as Record<string, unknown>));
       return true;
     }
     if (subpath === 'contacts/pending' && method === 'GET') {
@@ -95,7 +95,7 @@ export async function handleNetworkRoute(
       const username = subpath.slice('presence/'.length);
       if (!username) { json(res, 400, withTimestamp({ error: 'username is required' })); return true; }
       const presence = await network.checkPresence(username);
-      json(res, 200, withTimestamp(presence as Record<string, unknown>));
+      json(res, 200, withTimestamp(presence as unknown as Record<string, unknown>));
       return true;
     }
 
@@ -112,7 +112,7 @@ export async function handleNetworkRoute(
       }
       const settings = typeof body.settings === 'object' ? body.settings as Record<string, unknown> : undefined;
       const group = await network.createGroup(body.name, settings);
-      json(res, 201, withTimestamp(group as Record<string, unknown>));
+      json(res, 201, withTimestamp(group as unknown as Record<string, unknown>));
       return true;
     }
     if (subpath === 'groups/invitations' && method === 'GET') {

--- a/daemon/src/extensions/comms/network/sdk-bridge.ts
+++ b/daemon/src/extensions/comms/network/sdk-bridge.ts
@@ -9,7 +9,7 @@
  */
 
 import type {
-  CC4MeNetwork, CommunityConfig, CommunityStatusEvent,
+  A2ANetworkClient, CommunityConfig, CommunityStatusEvent,
   Message, ContactRequest, Broadcast, WireEnvelope,
   GroupMessage, GroupInvitationEvent,
 } from './sdk-types.js';
@@ -23,10 +23,10 @@ import { logCommsEntry, getDisplayName } from '../agent-comms.js';
 
 const log = createLogger('network:sdk');
 
-let _network: CC4MeNetwork | null = null;
+let _network: A2ANetworkClient | null = null;
 let _config: AgentConfig | null = null;
 
-export function getNetworkClient(): CC4MeNetwork | null {
+export function getNetworkClient(): A2ANetworkClient | null {
   return _network;
 }
 

--- a/daemon/src/extensions/comms/network/sdk-types.ts
+++ b/daemon/src/extensions/comms/network/sdk-types.ts
@@ -125,6 +125,7 @@ export interface PresenceInfo {
 }
 
 export interface RelayGroup {
+  id: string;
   groupId: string;
   name: string;
   owner: string;
@@ -133,6 +134,7 @@ export interface RelayGroup {
   settings?: Record<string, unknown>;
   memberCount?: number;
   createdAt: string;
+  [key: string]: unknown;
 }
 
 export interface RelayGroupMember {


### PR DESCRIPTION
## Summary
- Rename CC4MeNetwork type alias to A2ANetworkClient in sdk-bridge.ts
- Add `[key: string]: unknown` index signature to RelayGroup interface
- Add `id` field to RelayGroup for router A2ANetworkClient compatibility
- Fix 3 unsafe `Record<string,unknown>` casts in api.ts (use double-cast pattern)

## Test plan
- [x] daemon builds clean (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)