### PR TITLE
fix(daemon): bind to 127.0.0.1 by default

### DIFF
--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -360,7 +360,7 @@ const server = http.createServer((req, res) => {
 
 // ── Start ────────────────────────────────────────────────────
 
-const HOST = config.daemon.bind_host ?? '0.0.0.0'; // default: all interfaces for A2A
+const HOST = config.daemon.bind_host ?? '127.0.0.1'; // default: localhost only (security boundary)
 
 const MAX_BIND_RETRIES = 3;
 const BIND_RETRY_DELAY_MS = 1000;

--- a/kithkit.defaults.yaml
+++ b/kithkit.defaults.yaml
@@ -7,6 +7,7 @@ agent:
 
 daemon:
   port: 3847
+  bind_host: "127.0.0.1"
   log_level: info
   log_dir: logs
   # db_path: "~/Library/Application Support/kithkit/kithkit.db"


### PR DESCRIPTION
## Summary

- **Fixes #157** — daemon HTTP server defaulted to `0.0.0.0`, exposing the unauthenticated API on all network interfaces
- Changed default `bind_host` fallback from `0.0.0.0` to `127.0.0.1` in `daemon/src/main.ts`
- Made the default explicit in `kithkit.defaults.yaml`

## Security Impact

The entire REST API (todos, calendar, memories, agent spawn, orchestrator escalate) was accessible from any host on the LAN/WAN. Since the API has no authentication, this was a critical exposure. The fix ensures the daemon only listens on localhost by default, matching the documented security model.

## Files Changed

| File | Change |
|------|--------|
| `daemon/src/main.ts` | Default fallback `0.0.0.0` → `127.0.0.1` |
| `kithkit.defaults.yaml` | Added explicit `bind_host: "127.0.0.1"` |

## Test plan

- [ ] Start daemon without `bind_host` in config — verify it binds to `127.0.0.1`
- [ ] Set `bind_host: "0.0.0.0"` in config — verify override still works
- [ ] Confirm API is not reachable from another machine on the network

🤖 Generated with [Claude Code](https://claude.com/claude-code)