### PR TITLE
fix(daemon): rate-limit spawn and escalate endpoints (closes #159)

### DIFF
--- a/daemon/src/api/agents.ts
+++ b/daemon/src/api/agents.ts
@@ -19,6 +19,7 @@ import { loadProfiles } from '../agents/profiles.js';
 import { json, withTimestamp, parseBody } from './helpers.js';
 import { logActivity, getActivity } from './activity.js';
 import { update } from '../core/db.js';
+import { createRateLimiter } from './rate-limit.js';
 
 // ── Configuration ────────────────────────────────────────────
 
@@ -27,6 +28,8 @@ let profilesDir: string = '';
 export function setProfilesDir(dir: string): void {
   profilesDir = dir;
 }
+
+const spawnLimiter = createRateLimiter('spawn', 10);
 
 // ── Route handler ────────────────────────────────────────────
 
@@ -40,6 +43,8 @@ export async function handleAgentsRoute(
   try {
     // POST /api/agents/spawn
     if (pathname === '/api/agents/spawn' && method === 'POST') {
+      if (!spawnLimiter(req, res)) return true;
+
       const body = await parseBody(req);
 
       // Validate required fields

--- a/daemon/src/api/orchestrator.ts
+++ b/daemon/src/api/orchestrator.ts
@@ -22,6 +22,7 @@ import { randomUUID } from 'node:crypto';
 import { exec, query, update } from '../core/db.js';
 import { createLogger } from '../core/logger.js';
 import { logActivity } from './activity.js';
+import { createRateLimiter } from './rate-limit.js';
 
 const log = createLogger('orchestrator-api');
 
@@ -35,6 +36,8 @@ const SHUTDOWN_TIMEOUT_MS = 60_000;
 // Track the pending shutdown timer so we can cancel it on new spawn
 let pendingShutdownTimer: ReturnType<typeof setTimeout> | null = null;
 
+const escalateLimiter = createRateLimiter('escalate', 20);
+
 // ── Route handler ────────────────────────────────────────────
 
 export async function handleOrchestratorRoute(
@@ -46,6 +49,8 @@ export async function handleOrchestratorRoute(
 
   // POST /api/orchestrator/escalate — send task, spawn if needed
   if (pathname === '/api/orchestrator/escalate' && method === 'POST') {
+    if (!escalateLimiter(req, res)) return true;
+
     const body = await parseBody(req);
 
     if (!body.task || typeof body.task !== 'string') {

--- a/daemon/src/api/rate-limit.ts
+++ b/daemon/src/api/rate-limit.ts
@@ -1,0 +1,58 @@
+/**
+ * Simple in-memory sliding-window rate limiter.
+ * Tracks request timestamps per key and rejects when the window limit is exceeded.
+ */
+
+import type http from 'node:http';
+import { json, withTimestamp } from './helpers.js';
+
+interface WindowEntry {
+  timestamps: number[];
+}
+
+const windows = new Map<string, WindowEntry>();
+
+/**
+ * Create a rate-limit guard for a specific route.
+ * @param key — unique identifier for this limiter (e.g. 'spawn', 'escalate')
+ * @param max — max requests allowed in the window
+ * @param windowMs — window size in milliseconds (default 60_000 = 1 minute)
+ * @returns a function that returns true if the request is allowed, false if rate-limited (and sends 429)
+ */
+export function createRateLimiter(
+  key: string,
+  max: number,
+  windowMs: number = 60_000,
+): (req: http.IncomingMessage, res: http.ServerResponse) => boolean {
+  return (_req, res) => {
+    const now = Date.now();
+    let entry = windows.get(key);
+    if (!entry) {
+      entry = { timestamps: [] };
+      windows.set(key, entry);
+    }
+
+    // Slide: remove timestamps older than the window
+    entry.timestamps = entry.timestamps.filter((t) => now - t < windowMs);
+
+    if (entry.timestamps.length >= max) {
+      const retryAfter = Math.ceil(
+        (entry.timestamps[0]! + windowMs - now) / 1000,
+      );
+      res.setHeader('Retry-After', String(retryAfter));
+      json(res, 429, withTimestamp({
+        error: 'Too many requests',
+        retry_after_seconds: retryAfter,
+      }));
+      return false; // blocked
+    }
+
+    entry.timestamps.push(now);
+    return true; // allowed
+  };
+}
+
+/** Reset all limiters — useful for testing. */
+export function resetAllLimiters(): void {
+  windows.clear();
+}


### PR DESCRIPTION
## Summary
- Adds in-memory sliding-window rate limiter in new `daemon/src/api/rate-limit.ts`
- `POST /api/agents/spawn`: max 10 requests/minute
- `POST /api/orchestrator/escalate`: max 20 requests/minute
- Returns 429 with `Retry-After` header when limit exceeded

Closes #159

## Test plan
- [ ] Build passes (`npm run build --workspace=daemon`)
- [ ] Spawn endpoint returns 429 after 10 rapid requests
- [ ] Escalate endpoint returns 429 after 20 rapid requests
- [ ] Normal usage unaffected

Generated with [Claude Code](https://claude.com/claude-code)