### PR TITLE
fix(scheduler): add timeout to in-process handlers

### DIFF
--- a/daemon/src/automation/scheduler.ts
+++ b/daemon/src/automation/scheduler.ts
@@ -372,8 +372,18 @@ export class Scheduler {
     const startedAt = new Date().toISOString();
     const start = Date.now();
 
+    const timeoutMs = (task.config.timeout_ms as number) ?? 300_000; // 5 min default
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`In-process handler timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+      // Don't keep process alive just for the timeout
+      if (timer.unref) timer.unref();
+    });
+
     try {
-      await handler({ taskName: task.name, config: task.config });
+      await Promise.race([handler({ taskName: task.name, config: task.config }), timeoutPromise]);
       const durationMs = Date.now() - start;
       const finishedAt = new Date().toISOString();
 


### PR DESCRIPTION
## Summary

- Wraps in-process handler invocations with `Promise.race` against a configurable timeout
- Defaults to 5 minutes (matching subprocess timeout behavior)
- Per-task override via `task.config.timeout_ms`
- Ensures `task.running` is always cleared even if handler hangs

Closes #162

## Test plan

- [ ] Verify existing scheduler tests pass (`node --test daemon/src/__tests__/scheduler.test.ts`)
- [ ] Test with a handler that sleeps longer than timeout — should get failure result with "timed out" message
- [ ] Verify `task.running` is cleared after timeout (task can fire again on next schedule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)