### PR TITLE
fix(daily-digest): use correct todo status 'completed' not 'done'

### DIFF
--- a/daemon/src/automation/tasks/daily-digest.ts
+++ b/daemon/src/automation/tasks/daily-digest.ts
@@ -118,7 +118,7 @@ function getTodoActivity(): DigestSection {
     // Completed todos in last 24h (todos table has updated_at, not completed_at)
     const completed = query<TodoRow>(
       `SELECT id, title, status FROM todos
-       WHERE status = 'done'
+       WHERE status = 'completed'
          AND updated_at >= datetime('now', '-24 hours')
        ORDER BY updated_at DESC
        LIMIT 5`,
@@ -130,7 +130,7 @@ function getTodoActivity(): DigestSection {
 
     // Open todos count
     const openResult = query<{ count: number }>(
-      `SELECT COUNT(*) as count FROM todos WHERE status != 'done'`,
+      `SELECT COUNT(*) as count FROM todos WHERE status NOT IN ('completed', 'cancelled')`,
     );
     const openCount = openResult[0]?.count ?? 0;
     if (openCount > 0) {


### PR DESCRIPTION
## Summary

- Changed `status = 'done'` to `status = 'completed'` in completed todos query — 'done' is not a valid status
- Changed open todos count from `status != 'done'` to `status NOT IN ('completed', 'cancelled')` — properly excludes finished todos

Closes #164

## Test plan

- [ ] Verify daily-digest with completed todos in DB reports correct count
- [ ] Verify open todos count excludes both completed and cancelled
- [ ] Manual: `POST /api/tasks/daily-digest/run` and check output

🤖 Generated with [Claude Code](https://claude.com/claude-code)