### PR TITLE
fix(morning-briefing): wire to channel router, remove adapter stubs

### DIFF
--- a/daemon/src/automation/tasks/index.ts
+++ b/daemon/src/automation/tasks/index.ts
@@ -20,6 +20,7 @@ import { register as registerCommsHeartbeat } from './comms-heartbeat.js';
 import { register as registerPeerHeartbeat } from './peer-heartbeat.js';
 import { register as registerMetricsAggregation } from './api-metrics-aggregation.js';
 import { register as registerDailyDigest } from './daily-digest.js';
+import { register as registerMorningBriefing } from './morning-briefing.js';
 export { loadExternalTasks, type LoadResult } from './external-loader.js';
 
 /**
@@ -39,6 +40,7 @@ export function registerCoreTasks(scheduler: Scheduler): void {
     { name: 'peer-heartbeat', register: registerPeerHeartbeat },
     { name: 'api-metrics-aggregation', register: registerMetricsAggregation },
     { name: 'daily-digest', register: registerDailyDigest },
+    { name: 'morning-briefing', register: registerMorningBriefing },
   ];
 
   for (const { name, register } of registrations) {

--- a/daemon/src/automation/tasks/morning-briefing.ts
+++ b/daemon/src/automation/tasks/morning-briefing.ts
@@ -1,0 +1,312 @@
+/**
+ * Morning Briefing — daily summary task.
+ *
+ * Gathers calendar, weather, todos, overnight messages, and email status,
+ * then delivers via the channel router (POST /api/send).
+ *
+ * This is a core task handler. Instance-specific customisation (weather
+ * location, delivery channels) is driven by scheduler task config.
+ *
+ * Data sources:
+ * - Calendar: icalbuddy (macOS) + internal calendar DB
+ * - Weather: Open-Meteo API with wttr.in fallback
+ * - Todos: SQLite (open todos, priority-sorted)
+ * - Email: task_results from the email-check task
+ * - Overnight messages: daemon log scan
+ */
+
+import { execFile, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { query } from '../../core/db.js';
+import { loadConfig, getProjectDir } from '../../core/config.js';
+import { createLogger } from '../../core/logger.js';
+import type { Scheduler } from '../scheduler.js';
+
+const log = createLogger('morning-briefing');
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function execCommand(cmd: string, args: string[], timeoutMs = 10_000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { timeout: timeoutMs, maxBuffer: 512 * 1024 }, (err, stdout) => {
+      if (err) reject(err);
+      else resolve(stdout);
+    });
+  });
+}
+
+// ── Calendar ─────────────────────────────────────────────────
+
+function gatherCalendar(): string {
+  try {
+    const output = execSync(
+      'icalbuddy -n -nc -nrd -npn -ea -eep notes,url -df "%A, %b %e, %Y" -b "• " -iep title,datetime eventsToday',
+      { encoding: 'utf8', timeout: 10_000 },
+    ).trim();
+    return output || 'No events today.';
+  } catch {
+    return 'Calendar unavailable.';
+  }
+}
+
+function gatherInternalCalendar(): string {
+  try {
+    const now = new Date();
+    const todayStr = now.toISOString().slice(0, 10);
+    const events = query<{ title: string; start_time: string; all_day: number }>(
+      "SELECT title, start_time, all_day FROM calendar WHERE date(start_time) = date(?) ORDER BY start_time ASC",
+      todayStr,
+    );
+    if (events.length === 0) return '';
+    return events
+      .map(ev => {
+        const time = ev.all_day ? '' : ` ${ev.start_time.slice(11, 16)}`;
+        return `• ${ev.title}${time}`;
+      })
+      .join('\n');
+  } catch {
+    return '';
+  }
+}
+
+// ── Weather ──────────────────────────────────────────────────
+
+const WMO_CODES: Record<number, string> = {
+  0: 'Clear', 1: 'Mostly clear', 2: 'Partly cloudy', 3: 'Overcast',
+  45: 'Foggy', 48: 'Rime fog',
+  51: 'Light drizzle', 53: 'Drizzle', 55: 'Heavy drizzle',
+  61: 'Light rain', 63: 'Rain', 65: 'Heavy rain',
+  71: 'Light snow', 73: 'Snow', 75: 'Heavy snow',
+  80: 'Light showers', 81: 'Showers', 82: 'Heavy showers',
+  95: 'Thunderstorm', 96: 'Thunderstorm w/ hail', 99: 'Severe thunderstorm',
+};
+
+async function gatherWeather(location: string): Promise<string> {
+  try {
+    const geoRaw = await execCommand('/usr/bin/curl', [
+      '-s', '--max-time', '5',
+      `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(location)}&count=1`,
+    ]);
+    const geo = JSON.parse(geoRaw.trim());
+    if (!geo.results?.length) throw new Error('No geocoding results');
+    const { latitude, longitude, timezone } = geo.results[0];
+
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}` +
+      `&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,weather_code` +
+      `&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max` +
+      `&temperature_unit=fahrenheit&wind_speed_unit=mph` +
+      `&timezone=${encodeURIComponent(timezone)}&forecast_days=3`;
+
+    const raw = await execCommand('/usr/bin/curl', ['-s', '--max-time', '8', url]);
+    const data = JSON.parse(raw.trim());
+    const c = data.current;
+    const desc = WMO_CODES[c.weather_code as number] ?? `Code ${c.weather_code}`;
+    const feelsLike = c.apparent_temperature != null
+      ? ` (feels ${Math.round(c.apparent_temperature)}°)`
+      : '';
+
+    const currentLine = `${desc} ${Math.round(c.temperature_2m)}°F${feelsLike} · ` +
+      `Humidity ${c.relative_humidity_2m}% · Wind ${Math.round(c.wind_speed_10m)} mph`;
+
+    const days = data.daily;
+    const dayNames = ['Today', 'Tomorrow'];
+    const forecastLines: string[] = [];
+    for (let i = 0; i < Math.min(days.time.length, 3); i++) {
+      const label = dayNames[i] ??
+        new Date(days.time[i] + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short' });
+      const hi = Math.round(days.temperature_2m_max[i]);
+      const lo = Math.round(days.temperature_2m_min[i]);
+      const precip = days.precipitation_probability_max[i];
+      const dayDesc = WMO_CODES[days.weather_code[i] as number] ?? '';
+      const precipStr = precip > 10 ? ` · ${precip}% precip` : '';
+      forecastLines.push(`  ${label}: ${dayDesc}, ${hi}°/${lo}°F${precipStr}`);
+    }
+
+    return `${currentLine}\n${forecastLines.join('\n')}`;
+  } catch (err) {
+    log.warn('Open-Meteo failed, trying wttr.in fallback', { error: errMsg(err) });
+  }
+
+  try {
+    const loc = location.replace(/\s+/g, '+');
+    const current = await execCommand('/usr/bin/curl', [
+      '-s', '--max-time', '8',
+      `wttr.in/${loc}?format=%c+%t+|+Humidity:+%h+|+Wind:+%w`,
+    ]);
+    return current.trim() || 'Weather unavailable.';
+  } catch (err) {
+    log.warn('wttr.in also failed', { error: errMsg(err) });
+    return 'Weather unavailable.';
+  }
+}
+
+// ── Todos ────────────────────────────────────────────────────
+
+function gatherTodos(): string {
+  try {
+    const rows = query<{ title: string; priority: string; due_date: string | null }>(
+      `SELECT title, priority, due_date FROM todos
+       WHERE status NOT IN ('completed', 'cancelled')
+       ORDER BY CASE priority
+         WHEN 'critical' THEN 0 WHEN 'high' THEN 1
+         WHEN 'medium' THEN 2 ELSE 3 END
+       LIMIT 10`,
+    );
+    if (rows.length === 0) return 'No open to-dos.';
+    return rows
+      .map(r => `• ${r.title}${r.due_date ? ` (due: ${r.due_date})` : ''}`)
+      .join('\n');
+  } catch {
+    return 'To-do list unavailable.';
+  }
+}
+
+// ── Email (from task_results) ────────────────────────────────
+
+function gatherEmailSummary(): string {
+  try {
+    const rows = query<{ output: string | null }>(
+      `SELECT output FROM task_results
+       WHERE task_name = 'email-check' AND status = 'success'
+       ORDER BY id DESC LIMIT 1`,
+    );
+    if (rows.length > 0 && rows[0]!.output) {
+      return rows[0]!.output;
+    }
+    return 'No recent email data.';
+  } catch {
+    return 'Email data unavailable.';
+  }
+}
+
+// ── Overnight Messages ───────────────────────────────────────
+
+function gatherOvernightMessages(): string {
+  const logPath = path.join(getProjectDir(), 'logs/daemon.log');
+  try {
+    if (!fs.existsSync(logPath)) return 'No overnight messages.';
+
+    const eightHoursAgo = Date.now() - 8 * 60 * 60 * 1000;
+    const lines = fs.readFileSync(logPath, 'utf8').split('\n');
+    const messages: string[] = [];
+
+    for (const line of lines) {
+      if (!line) continue;
+      try {
+        const entry = JSON.parse(line);
+        if (new Date(entry.ts).getTime() < eightHoursAgo) continue;
+
+        if (entry.module === 'telegram' && entry.msg?.includes('Injected message from')) {
+          messages.push(`Telegram: ${entry.msg}`);
+        }
+        if (entry.module === 'agent-comms' && entry.msg?.includes('Received message from')) {
+          messages.push(`Agent: ${entry.msg}`);
+        }
+      } catch { /* skip non-JSON lines */ }
+    }
+
+    if (messages.length === 0) return 'No overnight messages.';
+    return [...new Set(messages)].slice(-10).join('\n');
+  } catch {
+    return 'Message log unavailable.';
+  }
+}
+
+// ── Delivery ─────────────────────────────────────────────────
+
+async function sendBriefing(message: string, channels?: string[]): Promise<void> {
+  const config = loadConfig();
+  const port = (config as unknown as Record<string, Record<string, unknown>>)?.daemon?.port ?? 3847;
+
+  const payload: Record<string, unknown> = {
+    message,
+    parse_mode: 'HTML',
+  };
+  if (channels && channels.length > 0) {
+    payload.channels = channels;
+  }
+
+  const resp = await fetch(`http://127.0.0.1:${port}/api/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Send API returned ${resp.status}`);
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────
+
+async function run(config: Record<string, unknown>): Promise<string> {
+  log.info('Gathering morning briefing data');
+
+  const location = (config.weather_location as string) ?? 'Baltimore';
+  const channels = config.channels as string[] | undefined;
+
+  const today = new Date().toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  // Gather data (parallel where possible)
+  const [weather] = await Promise.all([gatherWeather(location)]);
+
+  // Synchronous DB/filesystem queries
+  const calendar = gatherCalendar();
+  const internalCal = gatherInternalCalendar();
+  const todos = gatherTodos();
+  const email = gatherEmailSummary();
+  const overnight = gatherOvernightMessages();
+
+  // Format as Telegram-friendly HTML
+  const parts: string[] = [
+    `<b>Morning Briefing — ${today}</b>`,
+    '',
+    '<b>Weather</b>',
+    weather,
+    '',
+    '<b>Calendar</b>',
+    calendar,
+  ];
+
+  if (internalCal) {
+    parts.push('', '<b>Reminders</b>', internalCal);
+  }
+
+  parts.push('', '<b>To-Dos</b>', todos);
+
+  if (email !== 'No recent email data.') {
+    parts.push('', '<b>Email</b>', email);
+  }
+
+  if (overnight !== 'No overnight messages.') {
+    parts.push('', '<b>Overnight</b>', overnight);
+  }
+
+  const message = parts.join('\n').trim();
+
+  await sendBriefing(message, channels);
+
+  const summary = `Sent briefing: weather OK, ` +
+    `${calendar === 'No events today.' ? '0 events' : 'events listed'}, ` +
+    `${todos === 'No open to-dos.' ? '0 todos' : 'todos listed'}`;
+  log.info('Morning briefing sent', { summary });
+  return summary;
+}
+
+// ── Registration ─────────────────────────────────────────────
+
+export function register(scheduler: Scheduler): void {
+  scheduler.registerHandler('morning-briefing', async (ctx) => {
+    await run(ctx.config);
+  });
+}


### PR DESCRIPTION
## Summary

- Created core morning-briefing task handler in `daemon/src/automation/tasks/morning-briefing.ts`
- Uses channel router (`POST /api/send`) for delivery instead of removed adapter getters
- Email data sourced from `task_results` table (email-check task) instead of direct adapter calls
- Registered in core tasks index for automatic handler registration
- Gathers: calendar (icalbuddy + internal DB), weather (Open-Meteo + wttr.in fallback), todos, overnight messages, email summary

Closes #163

## Test plan

- [ ] Verify TypeScript compilation passes
- [ ] Test with morning-briefing task in config: `POST /api/tasks/morning-briefing/run`
- [ ] Verify delivery goes through channel router (check daemon logs for send API call)
- [ ] Test partial failure: disable weather API — briefing should still send with other sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)