### PR TITLE
fix(agents): handle invalid profile files gracefully in loadProfiles()

### DIFF
--- a/daemon/src/agents/profiles.ts
+++ b/daemon/src/agents/profiles.ts
@@ -182,8 +182,13 @@ export function loadProfiles(dir: string): Map<string, AgentProfile> {
   const files = fs.readdirSync(dir).filter(f => f.endsWith('.md')).sort();
 
   for (const file of files) {
-    const profile = loadProfile(path.join(dir, file));
-    profiles.set(profile.name, profile);
+    try {
+      const profile = loadProfile(path.join(dir, file));
+      profiles.set(profile.name, profile);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[profiles] Skipping ${file}: ${msg}`);
+    }
   }
 
   return profiles;


### PR DESCRIPTION
## Summary
- A single malformed .md file in the agents directory (e.g. a reference doc without YAML frontmatter) caused ProfileValidationError that crashed all profile loading
- This prevented ALL worker spawns via /api/agents/spawn (returned 500)
- Fix: wrap loadProfile() in try/catch so invalid files are skipped with a console warning

## Test plan
- [ ] Place a .md file without frontmatter in .claude/agents/ and verify profiles still load
- [ ] Verify valid profiles continue to load correctly
- [ ] POST /api/agents/spawn works with the fix applied

Generated with [Claude Code](https://claude.com/claude-code)