### PR TITLE
fix(timer): guard nag cycle against stale intervals

### DIFF
--- a/daemon/src/api/timer.ts
+++ b/daemon/src/api/timer.ts
@@ -115,6 +115,15 @@ function complete(entry: TimerEntry, status: TimerStatus): void {
 /** Start the nag cycle for a fired timer. `firedAt` is the epoch ms when it first fired. */
 function startNagCycle(entry: TimerEntry, firedAt: number): void {
   entry.nagHandle = setInterval(() => {
+    // Guard: stop if timer was acked/cancelled/expired since last nag
+    if (entry.status !== 'fired') {
+      if (entry.nagHandle !== undefined) {
+        clearInterval(entry.nagHandle);
+        entry.nagHandle = undefined;
+      }
+      return;
+    }
+
     const elapsed = Math.floor((Date.now() - firedAt) / 1000);
 
     if (elapsed >= MAX_NAG_DURATION_MS / 1000) {


### PR DESCRIPTION
## Summary
- Ghost timer bug: nag messages kept firing for up to 10 minutes after timers were acked or deleted
- Root cause: setInterval callback in startNagCycle() never re-checked timer status before injecting
- Fix: add a status guard that self-clears the interval if the timer is no longer in fired state

## Test plan
- [ ] Create a timer, let it fire, then ack it — verify nags stop immediately
- [ ] Create a timer, let it fire, then delete it — verify nags stop immediately
- [ ] Create a timer, let it fire, snooze it — verify nags stop then resume after snooze

Generated with [Claude Code](https://claude.com/claude-code)