### PR TITLE
refactor: extract hardcoded tool paths and port to config

### DIFF
--- a/daemon/src/agents/tmux.ts
+++ b/daemon/src/agents/tmux.ts
@@ -17,7 +17,7 @@ const log = createLogger('tmux');
 
 // ── Config ──────────────────────────────────────────────────
 
-export const TMUX_BIN = '/opt/homebrew/bin/tmux';
+export const TMUX_BIN = loadConfig().tools?.tmux_path ?? '/opt/homebrew/bin/tmux';
 export const TMUX_SOCKET = `/private/tmp/tmux-${process.getuid?.() ?? 501}/default`;
 
 const COMMS_SESSION = 'comms1';

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -14,7 +14,7 @@
 import fs from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { query, exec, update } from '../../core/db.js';
-import { resolveProjectPath } from '../../core/config.js';
+import { resolveProjectPath, loadConfig } from '../../core/config.js';
 import {
   isOrchestratorAlive as _isOrchestratorAlive,
   killOrchestratorSession as _killOrchestratorSession,
@@ -120,7 +120,7 @@ function buildShutdownPrompt(reason: string): string {
     `Shutdown requested: ${reason}`,
     'Please wrap up gracefully:',
     '1. If you have any unsent findings or context, send a final result to comms now:',
-    '   curl -s -X POST http://localhost:3847/api/messages -H "Content-Type: application/json" -d \'{"from":"orchestrator","to":"comms","type":"result","body":"<any final notes>"}\'',
+    `   curl -s -X POST http://localhost:${loadConfig().daemon.port}/api/messages -H "Content-Type: application/json" -d '{"from":"orchestrator","to":"comms","type":"result","body":"<any final notes>"}'`,
     '2. Then exit by running: exit',
     '',
     'If you are actively working on something, say so — the daemon will check again later.',

--- a/daemon/src/core/config.ts
+++ b/daemon/src/core/config.ts
@@ -52,12 +52,20 @@ export interface TmuxConfig {
   session?: string;
 }
 
+export interface ToolsConfig {
+  tmux_path: string;
+  himalaya_path: string;
+  ffmpeg_path: string;
+  whisper_cli_path: string;
+}
+
 export interface KithkitConfig {
   agent: AgentConfig;
   tmux?: TmuxConfig;
   daemon: DaemonConfig;
   scheduler: SchedulerConfig;
   security: SecurityConfig;
+  tools?: ToolsConfig;
 }
 
 // ── Defaults ─────────────────────────────────────────────────
@@ -73,6 +81,12 @@ const DEFAULTS: KithkitConfig = {
   scheduler: { tasks: [] },
   security: {
     rate_limits: { incoming_max_per_minute: 5, outgoing_max_per_minute: 10 },
+  },
+  tools: {
+    tmux_path: '/opt/homebrew/bin/tmux',
+    himalaya_path: '/opt/homebrew/bin/himalaya',
+    ffmpeg_path: '/opt/homebrew/bin/ffmpeg',
+    whisper_cli_path: '/opt/homebrew/bin/whisper-cli',
   },
 };
 

--- a/daemon/src/extensions/comms/adapters/email/himalaya-provider.ts
+++ b/daemon/src/extensions/comms/adapters/email/himalaya-provider.ts
@@ -20,11 +20,12 @@ import type {
   ChannelCapabilities,
 } from '../../../../comms/adapter.js';
 import { createLogger } from '../../../../core/logger.js';
+import { loadConfig } from '../../../../core/config.js';
 
 const execFileAsync = promisify(execFile);
 const log = createLogger('bmo-email-himalaya');
 
-const HIMALAYA_BIN = '/opt/homebrew/bin/himalaya';
+const HIMALAYA_BIN = loadConfig().tools?.himalaya_path ?? '/opt/homebrew/bin/himalaya';
 
 // ── Types ────────────────────────────────────────────────────
 

--- a/daemon/src/extensions/voice/audio-utils.ts
+++ b/daemon/src/extensions/voice/audio-utils.ts
@@ -13,6 +13,7 @@ import os from 'node:os';
 import crypto from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { createLogger } from '../../core/logger.js';
+import { loadConfig } from '../../core/config.js';
 
 const log = createLogger('audio-utils');
 
@@ -42,7 +43,7 @@ export function cleanupTemp(filepath: string): void {
   }
 }
 
-const FFMPEG = '/opt/homebrew/bin/ffmpeg';
+const FFMPEG = loadConfig().tools?.ffmpeg_path ?? '/opt/homebrew/bin/ffmpeg';
 const CONVERT_TIMEOUT_MS = 15_000; // 15s max for any conversion
 
 /**

--- a/daemon/src/extensions/voice/stt.ts
+++ b/daemon/src/extensions/voice/stt.ts
@@ -13,10 +13,11 @@ import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createLogger } from '../../core/logger.js';
+import { loadConfig } from '../../core/config.js';
 
 const log = createLogger('stt');
 
-const WHISPER_CLI = '/opt/homebrew/bin/whisper-cli';
+const WHISPER_CLI = loadConfig().tools?.whisper_cli_path ?? '/opt/homebrew/bin/whisper-cli';
 const TRANSCRIBE_TIMEOUT_MS = 30_000; // 30s max for any transcription
 
 /**


### PR DESCRIPTION
## Summary
- Adds ToolsConfig interface with configurable paths for tmux, himalaya, ffmpeg, whisper-cli
- Replaces hardcoded /opt/homebrew/bin/* paths across 5 files with config reads
- Fixes hardcoded localhost:3847 in orchestrator-idle.ts to use config.daemon.port
- All paths have sensible defaults — zero breaking changes

## Motivation
Hardcoded paths break on non-Homebrew installs (Linux, manual installs, different macOS setups). The hardcoded port meant the orchestrator prompt would use the wrong port if daemon.port was overridden.

## Config example
Users can now add to kithkit.config.yaml:
```yaml
tools:
  tmux_path: /usr/local/bin/tmux
  himalaya_path: /usr/local/bin/himalaya
  ffmpeg_path: /usr/bin/ffmpeg
  whisper_cli_path: /usr/local/bin/whisper-cli
```

## Test plan
- [ ] Build passes (npx tsc --noEmit)
- [ ] Daemon starts without tools config (defaults used)
- [ ] Daemon starts with custom tools config
- [ ] Tool paths resolve correctly at runtime

Generated with [Claude Code](https://claude.com/claude-code)