### PR TITLE
refactor: extract hardcoded URL endpoints to config

### DIFF
--- a/daemon/src/automation/tasks/morning-briefing.ts
+++ b/daemon/src/automation/tasks/morning-briefing.ts
@@ -90,13 +90,13 @@ async function gatherWeather(location: string): Promise<string> {
   try {
     const geoRaw = await execCommand('/usr/bin/curl', [
       '-s', '--max-time', '5',
-      `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(location)}&count=1`,
+      `${loadConfig().weather?.geocoding_api_url ?? 'https://geocoding-api.open-meteo.com/v1/search'}?name=${encodeURIComponent(location)}&count=1`,
     ]);
     const geo = JSON.parse(geoRaw.trim());
     if (!geo.results?.length) throw new Error('No geocoding results');
     const { latitude, longitude, timezone } = geo.results[0];
 
-    const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}` +
+    const url = `${loadConfig().weather?.forecast_api_url ?? 'https://api.open-meteo.com/v1/forecast'}?latitude=${latitude}&longitude=${longitude}` +
       `&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,weather_code` +
       `&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max` +
       `&temperature_unit=fahrenheit&wind_speed_unit=mph` +
@@ -136,7 +136,7 @@ async function gatherWeather(location: string): Promise<string> {
     const loc = location.replace(/\s+/g, '+');
     const current = await execCommand('/usr/bin/curl', [
       '-s', '--max-time', '8',
-      `wttr.in/${loc}?format=%c+%t+|+Humidity:+%h+|+Wind:+%w`,
+      `${loadConfig().weather?.wttr_base_url ?? 'https://wttr.in'}/${loc}?format=%c+%t+|+Humidity:+%h+|+Wind:+%w`,
     ]);
     return current.trim() || 'Weather unavailable.';
   } catch (err) {

--- a/daemon/src/core/config.ts
+++ b/daemon/src/core/config.ts
@@ -81,6 +81,16 @@ export interface TaskRunnerConfig {
   max_output_chars: number;
 }
 
+export interface WeatherConfig {
+  geocoding_api_url: string;
+  forecast_api_url: string;
+  wttr_base_url: string;
+}
+
+export interface EmailConfig {
+  fastmail_jmap_session_url: string;
+}
+
 export interface KithkitConfig {
   agent: AgentConfig;
   tmux?: TmuxConfig;
@@ -91,6 +101,8 @@ export interface KithkitConfig {
   timers?: TimerConfig;
   voice?: VoiceConfig;
   task_runner?: TaskRunnerConfig;
+  weather?: WeatherConfig;
+  email?: EmailConfig;
 }
 
 // ── Defaults ─────────────────────────────────────────────────
@@ -116,6 +128,14 @@ const DEFAULTS: KithkitConfig = {
   timers: { nag_interval_ms: 30_000, max_nag_duration_ms: 600_000, default_snooze_seconds: 300 },
   voice: { max_audio_bytes: 10 * 1024 * 1024, max_tts_chars: 500, response_timeout_ms: 30_000, audio_convert_timeout_ms: 15_000, transcription_timeout_ms: 30_000, client_stale_timeout_ms: 60_000, client_prune_interval_ms: 15_000 },
   task_runner: { default_timeout_ms: 300_000, max_buffer_bytes: 1024 * 1024, max_output_chars: 50_000 },
+  weather: {
+    geocoding_api_url: 'https://geocoding-api.open-meteo.com/v1/search',
+    forecast_api_url: 'https://api.open-meteo.com/v1/forecast',
+    wttr_base_url: 'https://wttr.in',
+  },
+  email: {
+    fastmail_jmap_session_url: 'https://api.fastmail.com/.well-known/jmap',
+  },
 };
 
 // ── Deep merge ───────────────────────────────────────────────

--- a/daemon/src/extensions/comms/adapters/email/jmap-provider.ts
+++ b/daemon/src/extensions/comms/adapters/email/jmap-provider.ts
@@ -19,6 +19,7 @@ import type {
   Verbosity,
   ChannelCapabilities,
 } from '../../../../comms/adapter.js';
+import { loadConfig } from '../../../../core/config.js';
 import { readKeychain } from '../../../../core/keychain.js';
 import { createLogger } from '../../../../core/logger.js';
 
@@ -383,7 +384,7 @@ export class BmoJmapAdapter implements ChannelAdapter {
 
   private async _getSession(): Promise<JmapSession> {
     await this._getCreds();
-    const response = await fetch('https://api.fastmail.com/.well-known/jmap', {
+    const response = await fetch(loadConfig().email?.fastmail_jmap_session_url ?? 'https://api.fastmail.com/.well-known/jmap', {
       method: 'GET',
       headers: this._getHeaders(),
     });


### PR DESCRIPTION
## Summary
- Adds WeatherConfig and EmailConfig interfaces to config system
- Extracts weather API URLs (Open-Meteo, wttr.in) and Fastmail JMAP URL to config
- All URLs have defaults matching current values — zero breaking changes
- Phase 3 (final) of hardcoded value extraction (Phase 1: PR #183, Phase 2: PR #184)

## Test plan
- [ ] Build passes
- [ ] Morning briefing works with default weather URLs
- [ ] JMAP email provider works with default Fastmail URL

Generated with [Claude Code](https://claude.com/claude-code)