### PR TITLE
fix: ghost timer bug — orphaned nag cycles survive restart

### DIFF
--- a/daemon/src/agents/tmux.ts
+++ b/daemon/src/agents/tmux.ts
@@ -289,6 +289,26 @@ export function listSessions(): string[] {
   }
 }
 
+// ── Session liveness check ──────────────────────────────────
+
+/**
+ * Check whether the tmux session for a given agent ID is currently alive.
+ * Returns true if the session exists, false otherwise.
+ */
+export function isSessionAlive(agentId: string): boolean {
+  const session = resolveSession(agentId);
+  if (!session) return false;
+
+  try {
+    execFileSync(TMUX_BIN, ['-S', TMUX_SOCKET, 'has-session', '-t', `=${session}`], {
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ── Testing ─────────────────────────────────────────────────
 
 export function _getCommsSession(): string { return COMMS_SESSION; }

--- a/daemon/src/api/orchestrator.ts
+++ b/daemon/src/api/orchestrator.ts
@@ -23,6 +23,7 @@ import { exec, query, update } from '../core/db.js';
 import { createLogger } from '../core/logger.js';
 import { logActivity } from './activity.js';
 import { createRateLimiter } from './rate-limit.js';
+import { cancelSessionTimers } from './timer.js';
 
 const log = createLogger('orchestrator-api');
 
@@ -269,6 +270,12 @@ export async function handleOrchestratorRoute(
       }),
     });
 
+    // Fix 3: cancel all orchestrator timers immediately on shutdown request
+    const cancelledTimers = cancelSessionTimers('orchestrator');
+    if (cancelledTimers > 0) {
+      log.info('Cancelled orchestrator timers on shutdown', { count: cancelledTimers });
+    }
+
     // Set a timeout to force-kill if no acknowledgment (cancellable on new spawn)
     pendingShutdownTimer = setTimeout(() => {
       pendingShutdownTimer = null;
@@ -287,6 +294,8 @@ export async function handleOrchestratorRoute(
           event_type: 'session_end',
           details: `Force-killed after ${effectiveTimeout / 1000}s shutdown timeout (was ${orchState})`,
         });
+        // Cancel any timers that fired during the shutdown window
+        cancelSessionTimers('orchestrator');
       }
     }, effectiveTimeout);
 

--- a/daemon/src/api/timer.ts
+++ b/daemon/src/api/timer.ts
@@ -15,7 +15,7 @@
 import type http from 'node:http';
 import { randomUUID } from 'node:crypto';
 import { json, withTimestamp, parseBody } from './helpers.js';
-import { injectMessage } from '../agents/tmux.js';
+import { injectMessage, isSessionAlive } from '../agents/tmux.js';
 import { createLogger } from '../core/logger.js';
 import { insert, update, query } from '../core/db.js';
 import { loadConfig } from '../core/config.js';
@@ -40,6 +40,9 @@ function normalizeAgentId(agent: string): string {
 const NAG_INTERVAL_MS = loadConfig().timers?.nag_interval_ms ?? 30_000;
 const MAX_NAG_DURATION_MS = loadConfig().timers?.max_nag_duration_ms ?? 600_000;
 const DEFAULT_SNOOZE_S = loadConfig().timers?.default_snooze_seconds ?? 300;
+
+/** Number of consecutive injection failures before auto-expiring a timer (circuit breaker). */
+const MAX_CONSECUTIVE_FAILURES = 3;
 
 // ── Timer state ──────────────────────────────────────────────
 
@@ -113,8 +116,15 @@ function complete(entry: TimerEntry, status: TimerStatus): void {
   log.info('Timer completed', { id: entry.id, status });
 }
 
-/** Start the nag cycle for a fired timer. `firedAt` is the epoch ms when it first fired. */
+/**
+ * Start the nag cycle for a fired timer. `firedAt` is the epoch ms when it first fired.
+ *
+ * Fix 4 — Circuit breaker: after MAX_CONSECUTIVE_FAILURES consecutive injection
+ * failures (session dead/gone), auto-expire the timer rather than nagging forever.
+ */
 function startNagCycle(entry: TimerEntry, firedAt: number): void {
+  let consecutiveFailures = 0;
+
   entry.nagHandle = setInterval(() => {
     // Guard: stop if timer was acked/cancelled/expired since last nag
     if (entry.status !== 'fired') {
@@ -136,8 +146,18 @@ function startNagCycle(entry: TimerEntry, firedAt: number): void {
     const nagText = `[timer] ${entry.message} (${elapsed}s ago, unacknowledged)`;
     const nagOk = injectMessage(entry.session, nagText);
     if (!nagOk) {
-      log.warn('Nag injection failed', { id: entry.id, elapsed });
+      consecutiveFailures++;
+      log.warn('Nag injection failed', { id: entry.id, elapsed, consecutiveFailures });
+
+      // Circuit breaker: auto-expire after too many consecutive failures
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        log.warn('Circuit breaker: auto-expiring timer after consecutive injection failures', {
+          id: entry.id, session: entry.session, consecutiveFailures,
+        });
+        complete(entry, 'expired');
+      }
     } else {
+      consecutiveFailures = 0; // reset on success
       log.info('Timer nag sent', { id: entry.id, elapsed });
     }
   }, NAG_INTERVAL_MS);
@@ -165,6 +185,11 @@ function fireTimer(entry: TimerEntry): void {
 /**
  * Reload active timers from the database on daemon startup.
  * Re-schedules pending/snoozed timers and restarts nag cycles for fired ones.
+ *
+ * Fix 2 — Session validation: before resuming a nag cycle for a fired timer,
+ * verify the target tmux session is alive. If the session is dead (e.g. orchestrator
+ * shut down while daemon was restarting), mark the timer expired instead of
+ * resurrecting orphaned nag cycles.
  */
 export function initTimers(): void {
   const rows = query<DbTimerRow>(
@@ -196,6 +221,12 @@ export function initTimers(): void {
         // Expired while daemon was down — mark it now
         complete(entry, 'expired');
         log.info('Timer expired during restart', { id: entry.id });
+      } else if (!isSessionAlive(row.session)) {
+        // Fix 2: target session is dead — don't resurrect orphaned nag cycles
+        complete(entry, 'expired');
+        log.info('Timer expired on restart — target session dead', {
+          id: entry.id, session: row.session,
+        });
       } else {
         startNagCycle(entry, firedAt);
         log.info('Timer nag cycle resumed', { id: entry.id });
@@ -209,6 +240,30 @@ export function initTimers(): void {
   }
 
   log.info('Timers reloaded from DB', { count: rows.length });
+}
+
+// ── Bulk cancellation ─────────────────────────────────────────
+
+/**
+ * Cancel all active timers for a given session (agent ID).
+ * Clears in-memory handles, updates DB status to 'cancelled', removes from Map.
+ * Returns the number of timers cancelled.
+ *
+ * Fix 3 — Called by orchestrator shutdown to clean up its timers.
+ */
+export function cancelSessionTimers(sessionId: string): number {
+  let count = 0;
+  for (const [id, entry] of timers) {
+    if (entry.session === sessionId && (entry.status === 'pending' || entry.status === 'fired' || entry.status === 'snoozed')) {
+      complete(entry, 'cancelled');
+      timers.delete(id);
+      count++;
+    }
+  }
+  if (count > 0) {
+    log.info('Cancelled timers for session', { sessionId, count });
+  }
+  return count;
 }
 
 // ── Route handler ────────────────────────────────────────────
@@ -289,13 +344,31 @@ export async function handleTimerRoute(
   // DELETE /api/timer/:id — cancel a timer
   if (!subpath && method === 'DELETE') {
     const entry = timers.get(id);
-    if (!entry) {
+    if (entry) {
+      complete(entry, 'cancelled');
+      timers.delete(id);
+      log.info('Timer cancelled', { id });
+      json(res, 200, withTimestamp({ id, cancelled: true }));
+      return true;
+    }
+
+    // Fix 1: not in memory — fall back to DB in case daemon restarted
+    const rows = query<DbTimerRow>(`SELECT * FROM timers WHERE id = ?`, id);
+    if (rows.length === 0) {
       json(res, 404, withTimestamp({ error: 'Timer not found' }));
       return true;
     }
-    complete(entry, 'cancelled');
-    timers.delete(id);
-    log.info('Timer cancelled', { id });
+    const row = rows[0];
+    // Only update if the timer isn't already in a terminal state
+    if (row.status === 'pending' || row.status === 'fired' || row.status === 'snoozed') {
+      update('timers', id, {
+        status: 'cancelled',
+        completed_at: new Date().toISOString(),
+      });
+      log.info('Timer cancelled via DB fallback', { id, was: row.status });
+    } else {
+      log.info('Timer already in terminal state — no-op cancel', { id, status: row.status });
+    }
     json(res, 200, withTimestamp({ id, cancelled: true }));
     return true;
   }


### PR DESCRIPTION
## Summary

Fixes the ghost timer bug where orchestrator-originated timers keep nagging every 30s after deletion, surviving daemon restarts and orchestrator shutdown.

**Root cause**: Two-part failure — orchestrator shutdown did not cancel its timers (leaving them as `fired` in DB), and `initTimers()` unconditionally reloaded fired timers on daemon restart, restarting nag cycles for dead sessions. Additionally, `DELETE /api/timer/:id` returned 404 for timers not in the in-memory Map, leaving DB state unchanged.

## Changes

### 1. DELETE endpoint DB fallback (timer.ts)
When a timer is not in the in-memory Map, falls back to checking the DB. If found as active, marks it `cancelled`. Only returns 404 if truly absent from both memory and DB.

### 2. Session validation in initTimers() (timer.ts)
Before resuming a nag cycle for a fired timer, checks if the target tmux session is still alive via `isSessionAlive()`. Dead session → mark expired immediately, no ghost cycle.

### 3. Orchestrator shutdown timer cleanup (orchestrator.ts)
`cancelSessionTimers('orchestrator')` fires both at shutdown request time and inside the force-kill timeout, ensuring timers cannot outlive their session.

### 4. Nag cycle circuit breaker (timer.ts)
`startNagCycle()` tracks consecutive injection failures. After 3 straight failures (dead session), auto-expires the timer. Defense-in-depth.

### New utility: isSessionAlive() (tmux.ts)
Exported helper that checks tmux `has-session` without side effects.

## Files changed
- `daemon/src/api/timer.ts` — fixes 1, 2, 4 + `cancelSessionTimers()` export
- `daemon/src/agents/tmux.ts` — `isSessionAlive()`
- `daemon/src/api/orchestrator.ts` — fix 3

## Test plan
- [x] TypeScript compiles clean (no new errors)
- [ ] Manual test: create timer, kill orchestrator, verify timer is cancelled
- [ ] Manual test: delete timer not in memory Map, verify DB is updated
- [ ] Manual test: daemon restart with dead-session fired timers, verify they are expired not resumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)