### PR TITLE
fix(agents): remove maxBudgetUsd worker budget cap

### DIFF
--- a/daemon/src/__tests__/lifecycle.test.ts
+++ b/daemon/src/__tests__/lifecycle.test.ts
@@ -74,7 +74,6 @@ const TEST_PROFILE: AgentProfile = {
   permissionMode: 'bypassPermissions',
   maxTurns: 20,
   effort: 'high',
-  maxBudgetUsd: 5,
   body: 'You are a research assistant.',
 };
 

--- a/daemon/src/agents/lifecycle.ts
+++ b/daemon/src/agents/lifecycle.ts
@@ -82,7 +82,6 @@ export interface SpawnRequest {
   prompt: string;
   cwd?: string;
   timeoutMs?: number;
-  maxBudgetUsd?: number;
   /** Which persistent agent spawned this worker ('comms' | 'orchestrator'). */
   spawned_by?: string;
 }
@@ -224,7 +223,6 @@ function startWorker(jobId: string, req: SpawnRequest): void {
     },
     cwd: req.cwd,
     timeoutMs: req.timeoutMs,
-    maxBudgetUsd: req.maxBudgetUsd ?? req.profile.maxBudgetUsd ?? undefined,
   };
 
   // SDK adapter assigns its own internal ID

--- a/daemon/src/agents/profiles.ts
+++ b/daemon/src/agents/profiles.ts
@@ -25,8 +25,6 @@ export interface AgentProfile {
   maxTurns: number;
   /** Controls how much effort Claude puts into responses (maps to SDK effort param) */
   effort: EffortLevel;
-  /** Per-worker cost cap in USD (maps to SDK maxBudgetUsd) */
-  maxBudgetUsd: number;
   /** Markdown body — becomes systemPrompt append content */
   body: string;
 }
@@ -51,7 +49,6 @@ const DEFAULTS: Omit<AgentProfile, 'name' | 'body'> = {
   permissionMode: 'bypassPermissions',
   maxTurns: 20,
   effort: 'high',
-  maxBudgetUsd: 1.0,
 };
 
 // ── Parsing ──────────────────────────────────────────────────
@@ -134,13 +131,6 @@ export function validateProfile(
     }
   }
 
-  // Validate maxBudgetUsd if provided
-  if (frontmatter.maxBudgetUsd !== undefined) {
-    if (typeof frontmatter.maxBudgetUsd !== 'number' || frontmatter.maxBudgetUsd <= 0) {
-      throw new ProfileValidationError('maxBudgetUsd must be a positive number');
-    }
-  }
-
   return {
     name: frontmatter.name as string,
     description: typeof frontmatter.description === 'string' ? frontmatter.description : DEFAULTS.description,
@@ -154,7 +144,6 @@ export function validateProfile(
     effort: VALID_EFFORT_LEVELS.includes(frontmatter.effort as typeof VALID_EFFORT_LEVELS[number])
       ? frontmatter.effort as EffortLevel
       : DEFAULTS.effort,
-    maxBudgetUsd: typeof frontmatter.maxBudgetUsd === 'number' ? frontmatter.maxBudgetUsd : DEFAULTS.maxBudgetUsd,
     body,
   };
 }

--- a/daemon/src/agents/sdk-adapter.ts
+++ b/daemon/src/agents/sdk-adapter.ts
@@ -44,8 +44,6 @@ export interface SpawnOptions {
   cwd?: string;
   /** Inactivity timeout in ms (default: 300000 = 5 min) */
   timeoutMs?: number;
-  /** Max budget in USD */
-  maxBudgetUsd?: number;
 }
 
 export type WorkerStatus = 'running' | 'completed' | 'failed' | 'timeout';
@@ -141,7 +139,6 @@ export function spawnWorker(opts: SpawnOptions): string {
   if (opts.profile.disallowedTools) sdkOptions.disallowedTools = opts.profile.disallowedTools;
   if (opts.profile.maxTurns) sdkOptions.maxTurns = opts.profile.maxTurns;
   if (opts.profile.effort) sdkOptions.effort = opts.profile.effort;
-  if (opts.maxBudgetUsd !== undefined) sdkOptions.maxBudgetUsd = opts.maxBudgetUsd;
   if (opts.cwd) sdkOptions.cwd = opts.cwd;
 
   if (opts.profile.permissionMode === 'bypassPermissions') {

--- a/daemon/src/api/agents.ts
+++ b/daemon/src/api/agents.ts
@@ -70,7 +70,6 @@ export async function handleAgentsRoute(
         prompt: body.prompt as string,
         cwd: typeof body.cwd === 'string' ? body.cwd : undefined,
         timeoutMs: typeof body.timeoutMs === 'number' ? body.timeoutMs : undefined,
-        maxBudgetUsd: typeof body.maxBudgetUsd === 'number' ? body.maxBudgetUsd : undefined,
         spawned_by: typeof body.spawned_by === 'string' ? body.spawned_by : 'comms',
       });
 


### PR DESCRIPTION
## Summary
- Removes all `maxBudgetUsd` plumbing per Dave directive — no budget cap on workers
- A worker hit the $1.00 default cap and failed; this removes the cap entirely
- 5 files changed, 18 lines removed (pure deletion)

## Files changed
- `agents/profiles.ts` — removed from interface, defaults, validation, parsing
- `agents/lifecycle.ts` — removed from SpawnRequest, SDK opts passthrough
- `agents/sdk-adapter.ts` — removed from SpawnOptions, SDK assignment
- `api/agents.ts` — removed from spawn request body parsing
- `__tests__/lifecycle.test.ts` — removed from mock profile

## Test plan
- [x] TypeScript compiles cleanly
- [ ] Existing tests pass (budget error test preserved — SDK can still return that error)
- [ ] Spawn a worker and confirm no budget-related failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)