### PR TITLE
fix(security): strip sensitive fields from /health for external requests

### DIFF
--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -189,19 +189,30 @@ const server = http.createServer((req, res) => {
   // Health endpoint
   if (req.method === 'GET' && url.pathname === '/health') {
     const health = getHealth(VERSION);
-    const extRoutes = getRegisteredRoutes();
     const ext = getExtension();
+
+    // Detect if request is from localhost or external (via tunnel/proxy)
+    const remoteAddr = req.socket.remoteAddress ?? '';
+    const cfIp = req.headers['cf-connecting-ip'] as string | undefined;
+    const isLocal = !cfIp && (remoteAddr === '127.0.0.1' || remoteAddr === '::1' || remoteAddr === '::ffff:127.0.0.1');
+
+    const response: Record<string, unknown> = {
+      ...health,
+      degraded: isDegraded(),
+      extension: ext ? ext.name : null,
+    };
+
+    // Only include sensitive details for localhost requests
+    if (isLocal) {
+      response.extensionRoutes = getRegisteredRoutes();
+      response.db_path = resolvedDbPath;
+    }
+
     res.writeHead(200, {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*',
     });
-    res.end(JSON.stringify({
-      ...health,
-      degraded: isDegraded(),
-      extension: ext ? ext.name : null,
-      extensionRoutes: extRoutes,
-      db_path: resolvedDbPath,
-    }));
+    res.end(JSON.stringify(response));
     return;
   }
 


### PR DESCRIPTION
## Summary

- Strip `db_path` and `extensionRoutes` from `/health` response for non-localhost requests
- Detect external requests via `Cf-Connecting-Ip` header (Cloudflare tunnel) and non-loopback `remoteAddress`
- Localhost requests without the CF header continue to receive full diagnostic info

## Test plan

- [ ] `curl http://localhost:3847/health` returns `db_path` and `extensionRoutes`
- [ ] Request through Cloudflare tunnel omits `db_path` and `extensionRoutes`
- [ ] LAN request (e.g. from another machine on 192.168.x.x) omits sensitive fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)