### PR TITLE
feat(security): add rate limiting to /agent/p2p endpoint

### DIFF
--- a/daemon/src/__tests__/rate-limiter.test.ts
+++ b/daemon/src/__tests__/rate-limiter.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { RateLimiter } from '../core/rate-limiter.js';
+
+describe('RateLimiter', () => {
+  let limiter: RateLimiter;
+
+  beforeEach(() => {
+    limiter = new RateLimiter(3, 1000); // 3 per second for testing
+  });
+
+  it('allows requests under the limit', () => {
+    assert.ok(limiter.check('ip1'));
+    assert.ok(limiter.check('ip1'));
+    assert.ok(limiter.check('ip1'));
+  });
+
+  it('blocks requests over the limit', () => {
+    limiter.check('ip1');
+    limiter.check('ip1');
+    limiter.check('ip1');
+    assert.ok(!limiter.check('ip1'));
+  });
+
+  it('tracks IPs independently', () => {
+    limiter.check('ip1');
+    limiter.check('ip1');
+    limiter.check('ip1');
+    assert.ok(!limiter.check('ip1'));
+    assert.ok(limiter.check('ip2')); // different IP, should be allowed
+  });
+
+  it('reports remaining correctly', () => {
+    assert.equal(limiter.remaining('ip1'), 3);
+    limiter.check('ip1');
+    assert.equal(limiter.remaining('ip1'), 2);
+    limiter.check('ip1');
+    assert.equal(limiter.remaining('ip1'), 1);
+    limiter.check('ip1');
+    assert.equal(limiter.remaining('ip1'), 0);
+  });
+
+  it('resets after window expires', async () => {
+    limiter = new RateLimiter(2, 100); // 100ms window
+    limiter.check('ip1');
+    limiter.check('ip1');
+    assert.ok(!limiter.check('ip1'));
+
+    await new Promise(r => setTimeout(r, 150));
+    assert.ok(limiter.check('ip1')); // window expired
+  });
+
+  it('stop clears all state', () => {
+    limiter.check('ip1');
+    limiter.startCleanup(100);
+    limiter.stop();
+    assert.equal(limiter.remaining('ip1'), 3); // cleared
+  });
+});

--- a/daemon/src/core/rate-limiter.ts
+++ b/daemon/src/core/rate-limiter.ts
@@ -1,0 +1,86 @@
+/**
+ * Simple in-memory rate limiter using sliding window counters.
+ *
+ * Tracks request counts per key (typically IP address) within a
+ * configurable time window. No external dependencies.
+ */
+
+import { createLogger } from './logger.js';
+
+const log = createLogger('rate-limiter');
+
+interface WindowEntry {
+  count: number;
+  resetAt: number; // Date.now() timestamp when window resets
+}
+
+export class RateLimiter {
+  private windows = new Map<string, WindowEntry>();
+  private maxRequests: number;
+  private windowMs: number;
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(maxRequests: number, windowMs: number) {
+    this.maxRequests = maxRequests;
+    this.windowMs = windowMs;
+  }
+
+  /**
+   * Check if a request from the given key is allowed.
+   * Returns true if allowed, false if rate limited.
+   */
+  check(key: string): boolean {
+    const now = Date.now();
+    const entry = this.windows.get(key);
+
+    if (!entry || now >= entry.resetAt) {
+      // New window
+      this.windows.set(key, { count: 1, resetAt: now + this.windowMs });
+      return true;
+    }
+
+    entry.count++;
+    if (entry.count > this.maxRequests) {
+      log.warn('Rate limit exceeded', { key, count: entry.count, limit: this.maxRequests });
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Get remaining requests for a key.
+   */
+  remaining(key: string): number {
+    const now = Date.now();
+    const entry = this.windows.get(key);
+    if (!entry || now >= entry.resetAt) return this.maxRequests;
+    return Math.max(0, this.maxRequests - entry.count);
+  }
+
+  /**
+   * Start periodic cleanup of expired entries.
+   */
+  startCleanup(intervalMs = 60_000): void {
+    if (this.cleanupTimer) return;
+    this.cleanupTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [key, entry] of this.windows) {
+        if (now >= entry.resetAt) {
+          this.windows.delete(key);
+        }
+      }
+    }, intervalMs);
+  }
+
+  /**
+   * Stop cleanup and clear all entries.
+   */
+  stop(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+    this.windows.clear();
+  }
+}

--- a/daemon/src/extensions/index.ts
+++ b/daemon/src/extensions/index.ts
@@ -48,10 +48,13 @@ import { parseBody } from '../api/helpers.js';
 import { UnifiedA2ARouter } from '../a2a/router.js';
 import { handleA2ARoute, setA2ARouter } from '../a2a/handler.js';
 import { sendMessage } from '../agents/message-router.js';
+import { RateLimiter } from '../core/rate-limiter.js';
 
 const log = createLogger('agent-extension');
 
 // ── State ────────────────────────────────────────────────────
+
+const p2pRateLimiter = new RateLimiter(30, 60_000); // 30 req/min per IP
 
 let _config: AgentConfig | null = null;
 let _scheduler: Scheduler | null = null;
@@ -67,6 +70,17 @@ async function handleAgentP2P(
   _searchParams: URLSearchParams,
 ): Promise<boolean> {
   if (req.method !== 'POST') return false;
+
+  // Rate limit by source IP
+  const clientIp = req.socket.remoteAddress ?? 'unknown';
+  if (!p2pRateLimiter.check(clientIp)) {
+    res.writeHead(429, {
+      'Content-Type': 'application/json',
+      'Retry-After': '60',
+    });
+    res.end(JSON.stringify({ ok: false, error: 'Rate limit exceeded' }));
+    return true;
+  }
 
   try {
     const envelope = await parseBody(req) as unknown as WireEnvelope;
@@ -240,6 +254,9 @@ async function loadInstanceExtensions(
 async function onInit(config: KithkitConfig, _server: http.Server): Promise<void> {
   _config = asAgentConfig(config);
 
+  // Start P2P rate limiter cleanup
+  p2pRateLimiter.startCleanup();
+
   // Enable vector search (sqlite-vec + ONNX embeddings)
   enableVectorSearch();
 
@@ -322,6 +339,7 @@ async function onShutdown(): Promise<void> {
   if (_instanceShutdown) {
     await _instanceShutdown();
   }
+  p2pRateLimiter.stop();
   await stopNetworkSDK();
   stopAgentComms();
   if (_scheduler) {


### PR DESCRIPTION
## Summary
- Adds an in-memory sliding window rate limiter (`RateLimiter` class) to `daemon/src/core/rate-limiter.ts`
- Applies 30 req/min per-IP rate limiting to the `/agent/p2p` endpoint, returning HTTP 429 when exceeded
- Includes cleanup lifecycle (start on init, stop on shutdown) to prevent memory leaks

## Test plan
- [x] Unit tests for `RateLimiter` class (6 tests, all passing): allows under limit, blocks over limit, independent IP tracking, remaining count, window expiry reset, stop/clear
- [ ] Manual test: send >30 requests in 60s to `/agent/p2p` and verify 429 response with `Retry-After: 60` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)