### PR TITLE
fix: restore session-start auto-inject prompt

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -210,4 +210,28 @@ fi
 
 echo "---"
 
+# ── Auto-resume: inject a bootstrap prompt via tmux ───────
+# Triggers the agent to act on the saved state already in context,
+# instead of sitting idle waiting for input.
+# Set KITHKIT_QUIET_START=1 to suppress (useful for debugging).
+if [ "${KITHKIT_QUIET_START:-0}" != "1" ]; then
+  TMUX_SOCKET="/private/tmp/tmux-$(id -u)/default"
+
+  if [ "$SOURCE" = "clear" ] || [ "$SOURCE" = "compact" ]; then
+    PROMPT="Session cleared and restored. Review the saved state above and follow any Next Steps in order."
+  else
+    PROMPT="Session auto-started. Review the saved state above. If there are Next Steps or action items, follow them in order. If there are no Next Steps, check todos and work on pending tasks autonomously."
+  fi
+
+  # Spawn a detached background job that waits for the session to initialize,
+  # then injects a prompt. nohup + disown ensures it survives hook exit.
+  nohup bash -c "
+    sleep 4
+    $TMUX_BIN -S '$TMUX_SOCKET' send-keys -t '$SESSION_NAME' -l '$PROMPT'
+    sleep 0.1
+    $TMUX_BIN -S '$TMUX_SOCKET' send-keys -t '$SESSION_NAME' Enter
+  " >/dev/null 2>&1 &
+  disown
+fi
+
 exit 0


### PR DESCRIPTION
## Summary
- Restores the tmux send-keys auto-inject block in session-start.sh
- This was accidentally removed in 2f4fe52 ("chore: remove dead code and deprecated auto-inject hook")
- Without this block, agents sit idle after session start instead of acting on their saved state
- The block injects a bootstrap prompt via tmux after a 4-second delay, triggering the agent to review saved state and act on next steps

## Test plan
- [ ] Verify session-start.sh has the auto-inject block (grep for 'send-keys')
- [ ] Start a fresh Claude session in tmux and confirm the auto-resume prompt is injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)