### PR TITLE
feat: LAN peer discovery + relay-first routing

### DIFF
--- a/daemon/src/a2a/router.ts
+++ b/daemon/src/a2a/router.ts
@@ -364,7 +364,28 @@ export class UnifiedA2ARouter {
       };
     }
 
-    // Auto: try LAN first (if peer in config), fall back to relay
+    // Auto: try relay first, fall back to LAN
+    const relayAttempt = await this.attemptRelay(qualified, request.payload, messageId);
+    attempts.push(relayAttempt);
+
+    if (relayAttempt.status === 'success') {
+      const relayStatus = relayAttempt.relayStatus ?? 'delivered';
+      this.logDBSuccess(messageId, target, 'dm', 'relay', request.payload, attempts);
+      return {
+        ok: true,
+        messageId,
+        target,
+        targetType: 'dm',
+        route: 'relay',
+        status: relayStatus,
+        attempts,
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    log.info(`Relay failed for ${target}, falling back to LAN`, { messageId });
+
+    // LAN fallback (only if peer in config)
     if (peer) {
       const lanAttempt = await this.attemptLAN(peer, request.payload, messageId);
       attempts.push(lanAttempt);
@@ -382,27 +403,6 @@ export class UnifiedA2ARouter {
           timestamp: new Date().toISOString(),
         };
       }
-
-      log.info(`LAN failed for ${target}, falling back to relay`, { messageId });
-    }
-
-    // Relay fallback (or relay-only if no peer)
-    const relayAttempt = await this.attemptRelay(qualified, request.payload, messageId);
-    attempts.push(relayAttempt);
-
-    if (relayAttempt.status === 'success') {
-      const relayStatus = relayAttempt.relayStatus ?? 'delivered';
-      this.logDBSuccess(messageId, target, 'dm', 'relay', request.payload, attempts);
-      return {
-        ok: true,
-        messageId,
-        target,
-        targetType: 'dm',
-        route: 'relay',
-        status: relayStatus,
-        attempts,
-        timestamp: new Date().toISOString(),
-      };
     }
 
     return {

--- a/daemon/src/automation/tasks/peer-heartbeat.ts
+++ b/daemon/src/automation/tasks/peer-heartbeat.ts
@@ -13,9 +13,21 @@
 
 import { createLogger } from '../../core/logger.js';
 import { loadConfig } from '../../core/config.js';
+import { scanForPeers } from '../../core/lan-discovery.js';
 import type { Scheduler } from '../scheduler.js';
 
 const log = createLogger('peer-heartbeat');
+
+const _lastScan = new Map<string, number>();
+const SCAN_COOLDOWN_MS = 10 * 60 * 1000; // 10 minutes
+
+function shouldScan(peerName: string): boolean {
+  const key = peerName.toLowerCase();
+  const last = _lastScan.get(key) ?? 0;
+  if (Date.now() - last < SCAN_COOLDOWN_MS) return false;
+  _lastScan.set(key, Date.now());
+  return true;
+}
 
 interface PeerConfig {
   name: string;
@@ -76,6 +88,16 @@ async function run(): Promise<void> {
         });
         failed++;
         log.debug(`Heartbeat failed for ${peer.name}`, { error: result.error });
+
+        // Attempt LAN discovery to find peer at a new IP
+        if (shouldScan(peer.name)) {
+          const discovered = await scanForPeers(peer.port ?? 3847);
+          const newIP = discovered.get(peer.name.toLowerCase());
+          if (newIP) {
+            comms.setPeerIpOverride(peer.name, newIP);
+            log.info(`Discovered ${peer.name} at new IP ${newIP}`);
+          }
+        }
       }
     } catch (err) {
       comms.updatePeerState(peer.name, {
@@ -86,6 +108,22 @@ async function run(): Promise<void> {
       log.warn(`Heartbeat error for ${peer.name}`, {
         error: err instanceof Error ? err.message : String(err),
       });
+
+      // Attempt LAN discovery to find peer at a new IP
+      if (shouldScan(peer.name)) {
+        try {
+          const discovered = await scanForPeers(peer.port ?? 3847);
+          const newIP = discovered.get(peer.name.toLowerCase());
+          if (newIP) {
+            comms.setPeerIpOverride(peer.name, newIP);
+            log.info(`Discovered ${peer.name} at new IP ${newIP}`);
+          }
+        } catch (scanErr) {
+          log.warn(`LAN discovery scan failed for ${peer.name}`, {
+            error: scanErr instanceof Error ? scanErr.message : String(scanErr),
+          });
+        }
+      }
     }
   }
 

--- a/daemon/src/core/lan-discovery.ts
+++ b/daemon/src/core/lan-discovery.ts
@@ -1,0 +1,94 @@
+/**
+ * LAN Peer Discovery — finds kithkit peers by scanning the ARP table.
+ *
+ * When a configured peer becomes unreachable at its known IP, this module
+ * scans the local network to find it at a new address.
+ */
+
+import { execFile } from 'node:child_process';
+import { createLogger } from './logger.js';
+
+const log = createLogger('lan-discovery');
+
+interface DiscoveredPeer {
+  name: string;
+  ip: string;
+}
+
+/**
+ * Parse the ARP table to get candidate IPs on the local network.
+ * Runs `arp -a` and extracts IPv4 addresses.
+ */
+function getArpIPs(): Promise<string[]> {
+  return new Promise((resolve) => {
+    execFile('arp', ['-a'], { timeout: 5000 }, (err, stdout) => {
+      if (err) {
+        log.warn('ARP table read failed', { error: err.message });
+        resolve([]);
+        return;
+      }
+      // Parse lines like: ? (192.168.12.169) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]
+      const ips: string[] = [];
+      for (const line of stdout.split('\n')) {
+        const match = line.match(/\((\d+\.\d+\.\d+\.\d+)\)/);
+        if (match) ips.push(match[1]);
+      }
+      resolve(ips);
+    });
+  });
+}
+
+/**
+ * Probe a single IP to check if it's running a kithkit daemon.
+ * Uses curl with a 1-second timeout to hit /status.
+ * Returns the agent name if found, null otherwise.
+ */
+function probeIP(ip: string, port: number): Promise<string | null> {
+  return new Promise((resolve) => {
+    const url = `http://${ip}:${port}/status`;
+    execFile('curl', ['-s', '--connect-timeout', '1', '--max-time', '2', url],
+      { timeout: 3000 }, (err, stdout) => {
+        if (err) { resolve(null); return; }
+        try {
+          const data = JSON.parse(stdout);
+          if (data.agent) {
+            resolve(data.agent.toLowerCase());
+          } else {
+            resolve(null);
+          }
+        } catch { resolve(null); }
+      });
+  });
+}
+
+/**
+ * Scan the local network for kithkit peers.
+ * Gets IPs from ARP table, probes each one in parallel.
+ * Returns a map of agentName -> IP.
+ */
+export async function scanForPeers(port = 3847): Promise<Map<string, string>> {
+  const ips = await getArpIPs();
+  if (ips.length === 0) {
+    log.debug('No ARP entries found');
+    return new Map();
+  }
+
+  log.info('Scanning for peers', { candidates: ips.length, port });
+
+  const results = await Promise.all(
+    ips.map(async (ip) => {
+      const name = await probeIP(ip, port);
+      return name ? { name, ip } : null;
+    })
+  );
+
+  const peers = new Map<string, string>();
+  for (const r of results) {
+    if (r) {
+      peers.set(r.name, r.ip);
+      log.info('Discovered peer', { name: r.name, ip: r.ip });
+    }
+  }
+
+  return peers;
+}

--- a/daemon/src/extensions/comms/agent-comms.ts
+++ b/daemon/src/extensions/comms/agent-comms.ts
@@ -60,6 +60,26 @@ export function setRouter(router: { send: (body: unknown) => Promise<{ ok: boole
   _router = router;
 }
 
+// Runtime peer IP overrides (from LAN discovery)
+const _peerIPOverrides = new Map<string, { ip: string; updatedAt: number }>();
+const IP_OVERRIDE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+export function setPeerIpOverride(peerName: string, ip: string): void {
+  const key = peerName.toLowerCase();
+  _peerIPOverrides.set(key, { ip, updatedAt: Date.now() });
+}
+
+export function getPeerIpOverride(peerName: string): string | null {
+  const key = peerName.toLowerCase();
+  const entry = _peerIPOverrides.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.updatedAt > IP_OVERRIDE_TTL_MS) {
+    _peerIPOverrides.delete(key);
+    return null;
+  }
+  return entry.ip;
+}
+
 // ── Peer Lookup ──────────────────────────────────────────────
 export function getPeerByName(name: string): PeerConfig | undefined {
   const peers = (_config as CommsConfig)?.['agent-comms']?.peers ?? [];
@@ -220,8 +240,11 @@ export async function sendViaLAN(
   agentName: string,
 ): Promise<Record<string, unknown>> {
   const payload = JSON.stringify(msg);
-  const hosts = [peer.host];
-  if (peer.ip && peer.ip !== peer.host) hosts.push(peer.ip);
+  const overrideIP = getPeerIpOverride(peer.name);
+  const hosts: string[] = [];
+  if (overrideIP) hosts.push(overrideIP);
+  if (peer.host && peer.host !== overrideIP) hosts.push(peer.host);
+  if (peer.ip && peer.ip !== peer.host && peer.ip !== overrideIP) hosts.push(peer.ip);
 
   // Compute HMAC signature if shared secret is available
   let signatureHeaders: string[] = [];


### PR DESCRIPTION
## Summary

- **LAN Peer Discovery**: New `lan-discovery.ts` module that scans the ARP table to find kithkit peers at new IPs when heartbeats fail. Integrates with `peer-heartbeat.ts` (10-minute scan throttle) and `agent-comms.ts` (IP override cache with 30-minute TTL).
- **Relay-First Routing**: Flips the auto-mode routing in `router.ts` from LAN-first to relay-first with LAN fallback, improving reliability when the relay server is available.

Relates to todo #16.

## Test plan

- [ ] Verify `arp -a` parsing extracts IPs correctly on macOS
- [ ] Confirm peer probe via `/status` endpoint returns agent name
- [ ] Test IP override cache: set override, verify it's used in `sendViaLAN` host list (priority position)
- [ ] Test TTL expiry: override older than 30 minutes should be purged
- [ ] Test scan throttle: second scan within 10 minutes for same peer should be skipped
- [ ] Verify heartbeat failure triggers LAN discovery and sets IP override
- [ ] Test relay-first routing: auto mode should attempt relay before LAN
- [ ] Test relay failure falls back to LAN when peer is in config
- [ ] Test both routes failing returns proper error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)