### PR TITLE
fix: promote top-level chat_id into metadata for Telegram routing

### DIFF
--- a/daemon/src/api/send.ts
+++ b/daemon/src/api/send.ts
@@ -51,8 +51,17 @@ export async function handleSendRoute(
         }
       }
 
+      // Merge top-level chat_id into metadata so the Telegram adapter receives it.
+      // Explicit metadata.chatId from the caller takes precedence over top-level chat_id.
+      const metadata: Record<string, unknown> = {
+        ...(body.metadata as Record<string, unknown> | undefined),
+      };
+      if (typeof body.chat_id === 'string' && !metadata.chatId) {
+        metadata.chatId = body.chat_id;
+      }
+
       const results = await routeMessage(
-        { text: body.message as string, metadata: body.metadata as Record<string, unknown> | undefined },
+        { text: body.message as string, metadata },
         channels,
       );
 


### PR DESCRIPTION
## Summary
- Fixes the bug where `POST /api/send` ignores the top-level `chat_id` field, causing all Telegram messages to route to the bot's default reply chat instead of the specified target
- Merges `body.chat_id` (snake_case convenience field) into `metadata.chatId` before calling `routeMessage()`
- Explicit `metadata.chatId` from the caller takes precedence over top-level `chat_id` to preserve backward compatibility

## Test plan
- [ ] Send `POST /api/send {"channel":"telegram","chat_id":"8254610246","message":"test"}` and verify it arrives at chat 8254610246 (Chrissy's DM)
- [ ] Send `POST /api/send {"channel":"telegram","chat_id":"-1003826239252","message":"test"}` and verify it arrives at the group chat
- [ ] Send with explicit `metadata.chatId` and confirm it is NOT overwritten by top-level `chat_id`
- [ ] Send without any `chat_id` and confirm default behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)