### PR TITLE
fix: only persist reply chat ID for private/DM chats

### DIFF
--- a/daemon/src/extensions/comms/adapters/telegram.ts
+++ b/daemon/src/extensions/comms/adapters/telegram.ts
@@ -742,8 +742,12 @@ function handleReaction(reaction: MessageReactionUpdated): void {
   if (removed.length > 0) parts.push(`removed ${removed.join(' ')}`);
 
   const chatId = reaction.chat.id.toString();
-  _replyChatId = chatId;
-  persistReplyChatId(chatId);
+  const chatType = reaction.chat.type ?? 'private';
+  // Only update persisted reply chat ID for private/DM chats.
+  if (chatType === 'private') {
+    _replyChatId = chatId;
+    persistReplyChatId(chatId);
+  }
 
   if (commsSessionExists()) {
     injectToComms(`[Telegram] ${firstName} ${parts.join(', ')} on a message`);
@@ -832,8 +836,12 @@ export class BmoTelegramAdapter implements ChannelAdapter {
     const ctx = extractMessageContext(msg, token);
     if (ctx.isSelf) return;
 
-    _replyChatId = ctx.replyChatId;
-    persistReplyChatId(ctx.replyChatId);
+    // Only update persisted reply chat ID for private/DM chats.
+    // Group chat messages should not override the default DM target.
+    if (ctx.chatType === 'private') {
+      _replyChatId = ctx.replyChatId;
+      persistReplyChatId(ctx.replyChatId);
+    }
 
     const { senderId, replyChatId, firstName, chatType } = ctx;
 


### PR DESCRIPTION
## Summary
- Group chat inbound messages were overwriting `_replyChatId`, causing all subsequent `/api/send` calls (without explicit `chat_id`) to route to the group instead of the owner's DM
- Added guard in `handleUpdate()` and `handleReaction()` to only persist `_replyChatId` for `private` chat type
- Group messages still get replies sent to the group (via local variable in `processIncomingMessage`), but the persisted default target stays as the owner's DM

## Test plan
- [ ] Send a DM to the bot → verify `reply-chat-id.txt` updates to DM chat ID
- [ ] Send a message in a group where the bot is present → verify `reply-chat-id.txt` does NOT change
- [ ] After group message, call `POST /api/send` without `chat_id` → verify it goes to DM, not group
- [ ] React to a message in a group → verify `reply-chat-id.txt` does NOT change
- [ ] React to a DM → verify `reply-chat-id.txt` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)