### PR TITLE
fix(api): add status and priority query filters to GET /api/todos

### DIFF
--- a/daemon/src/__tests__/state.test.ts
+++ b/daemon/src/__tests__/state.test.ts
@@ -361,6 +361,72 @@ describe('State API', { concurrency: 1 }, () => {
     });
   });
 
+  // ── Todo query filters ───────────────────────────────────────
+
+  describe('Todo query filters', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('filters todos by ?status= query parameter', async () => {
+      await request('POST', '/api/todos', { title: 'Pending task' });
+      const created = JSON.parse((await request('POST', '/api/todos', { title: 'Done task' })).body);
+      await request('PUT', `/api/todos/${created.id}`, { status: 'completed' });
+
+      const allRes = await request('GET', '/api/todos');
+      assert.equal(JSON.parse(allRes.body).data.length, 2, 'Should have 2 total todos');
+
+      const pendingRes = await request('GET', '/api/todos?status=pending');
+      assert.equal(pendingRes.status, 200);
+      const pendingBody = JSON.parse(pendingRes.body);
+      assert.equal(pendingBody.data.length, 1, 'Should have 1 pending todo');
+      assert.equal(pendingBody.data[0].title, 'Pending task');
+      assert.equal(pendingBody.data[0].status, 'pending');
+
+      const completedRes = await request('GET', '/api/todos?status=completed');
+      const completedBody = JSON.parse(completedRes.body);
+      assert.equal(completedBody.data.length, 1, 'Should have 1 completed todo');
+      assert.equal(completedBody.data[0].title, 'Done task');
+    });
+
+    it('filters todos by ?priority= query parameter', async () => {
+      await request('POST', '/api/todos', { title: 'High priority', priority: 'high' });
+      await request('POST', '/api/todos', { title: 'Low priority', priority: 'low' });
+      await request('POST', '/api/todos', { title: 'Also low', priority: 'low' });
+
+      const highRes = await request('GET', '/api/todos?priority=high');
+      assert.equal(highRes.status, 200);
+      const highBody = JSON.parse(highRes.body);
+      assert.equal(highBody.data.length, 1, 'Should have 1 high priority todo');
+      assert.equal(highBody.data[0].title, 'High priority');
+
+      const lowRes = await request('GET', '/api/todos?priority=low');
+      const lowBody = JSON.parse(lowRes.body);
+      assert.equal(lowBody.data.length, 2, 'Should have 2 low priority todos');
+    });
+
+    it('ignores invalid filter values', async () => {
+      await request('POST', '/api/todos', { title: 'A todo' });
+
+      const res = await request('GET', '/api/todos?status=bogus');
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.data.length, 1, 'Invalid filter should be ignored, returning all todos');
+    });
+
+    it('combines status and priority filters', async () => {
+      await request('POST', '/api/todos', { title: 'High pending', priority: 'high' });
+      await request('POST', '/api/todos', { title: 'Low pending', priority: 'low' });
+      const created = JSON.parse((await request('POST', '/api/todos', { title: 'High done', priority: 'high' })).body);
+      await request('PUT', `/api/todos/${created.id}`, { status: 'completed' });
+
+      const res = await request('GET', '/api/todos?status=pending&priority=high');
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.data.length, 1, 'Should match only high+pending');
+      assert.equal(body.data[0].title, 'High pending');
+    });
+  });
+
   // ── Usage endpoint ───────────────────────────────────────────
 
   describe('Usage endpoint', () => {

--- a/daemon/src/api/state.ts
+++ b/daemon/src/api/state.ts
@@ -122,7 +122,12 @@ export async function handleStateRoute(
   try {
     // ── Todos ──────────────────────────────────────────────
     if (pathname === '/api/todos' && method === 'GET') {
-      const todos = list<Todo>('todos', undefined, 'created_at DESC');
+      const filter: Record<string, unknown> = {};
+      const status = searchParams.get('status');
+      if (status && VALID_TODO_STATUSES.includes(status)) filter.status = status;
+      const priority = searchParams.get('priority');
+      if (priority && VALID_PRIORITIES.includes(priority)) filter.priority = priority;
+      const todos = list<Todo>('todos', Object.keys(filter).length ? filter : undefined, 'created_at DESC');
       json(res, 200, withTimestamp({ data: todos }));
       return true;
     }


### PR DESCRIPTION
## Summary
- **Bug**: `GET /api/todos` ignored query parameters like `?status=pending`, always returning all todos
- **Fix**: Read `status` and `priority` from `searchParams` and pass them as a filter object to `list()`. Invalid values are silently ignored (returns all todos).
- **Tests**: Added 4 new test cases covering status filtering, priority filtering, invalid value handling, and combined filters

## Changes
- `daemon/src/api/state.ts` — Build filter object from `?status=` and `?priority=` query params before calling `list()`
- `daemon/src/__tests__/state.test.ts` — New "Todo query filters" describe block with 4 tests

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 27 tests pass (`node --test dist/__tests__/state.test.js`)
- [ ] Manual verification: `curl 'localhost:3847/api/todos?status=pending'` returns only pending todos

🤖 Generated with [Claude Code](https://claude.com/claude-code)