### PR TITLE
fix: add read-before-write instruction to save-state skill

### DIFF
--- a/.claude/skills/save-state/SKILL.md
+++ b/.claude/skills/save-state/SKILL.md
@@ -80,6 +80,7 @@ Needs to work without JavaScript for accessibility.
    - Include file paths for easy navigation
 
 3. **Write State File**
+   - **Read `.claude/state/assistant-state.md` first** (the Write tool requires reading before overwriting — skip if file doesn't exist yet)
    - Write to `.claude/state/assistant-state.md`
    - Overwrites previous state (it's current state, not history)
 


### PR DESCRIPTION
## Summary
- Adds instruction to Read the state file before writing, preventing Write tool errors
- The Write tool requires reading a file before overwriting — save-state was missing this step
- Affects all agents using the save-state skill

## Test plan
- [ ] Agent can successfully save state without Write tool error

🤖 Generated with [Claude Code](https://claude.com/claude-code)