### PR TITLE
fix(scripts): config-driven skip-permissions mode

### DIFF
--- a/kithkit.defaults.yaml
+++ b/kithkit.defaults.yaml
@@ -5,6 +5,9 @@
 agent:
   name: Assistant
 
+claude:
+  skip_permissions: false    # Set true to always pass --dangerously-skip-permissions
+
 daemon:
   port: 3847
   bind_host: "127.0.0.1"

--- a/scripts/start-tmux.sh
+++ b/scripts/start-tmux.sh
@@ -10,6 +10,7 @@
 #   ./start-tmux.sh                    # Start new session or attach to existing
 #   ./start-tmux.sh --detach           # Start detached (for launchd)
 #   ./start-tmux.sh --skip-permissions # Skip Claude's permission prompts
+#   Config: set claude.skip_permissions=true in kithkit.config.yaml (preferred, survives reboots)
 
 set -e
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -33,6 +33,20 @@ fi
 # Build arguments array
 ARGS=()
 
+# Permission mode: config-driven bypass (survives reboots)
+SKIP_PERMS=$(read_config '.claude.skip_permissions' 'false')
+if [ "$SKIP_PERMS" = "true" ]; then
+    ARGS+=("--dangerously-skip-permissions")
+fi
+
+# Fallback: state file from previous --skip-permissions invocation
+if [ -f "$STATE_DIR/skip-permissions" ]; then
+    # Only add if not already added from config
+    if [ "$SKIP_PERMS" != "true" ]; then
+        ARGS+=("--dangerously-skip-permissions")
+    fi
+fi
+
 # Add system prompt if identity file exists
 if [ -f "$IDENTITY_FILE" ]; then
     ARGS+=("--append-system-prompt" "$(cat "$IDENTITY_FILE")")


### PR DESCRIPTION
## Summary

- Adds `claude.skip_permissions: true` config option in `kithkit.config.yaml` that persists `--dangerously-skip-permissions` across reboots
- Scripts read the config at startup instead of relying solely on CLI flags that get lost
- Retains the state-file fallback from commit 59bbefc as a secondary mechanism

Fixes #208

## Changes

| File | Change |
|------|--------|
| `kithkit.defaults.yaml` | Added `claude.skip_permissions: false` default |
| `scripts/start.sh` | Reads config + state file, injects `--dangerously-skip-permissions` |
| `scripts/start-tmux.sh` | Usage comment documenting config option |

## Test plan

- [ ] Set `claude.skip_permissions: true` in config, run `start-tmux.sh` — verify claude launches with skip-permissions
- [ ] Without config set, run with `--skip-permissions` CLI flag — verify state file written and flag persisted on restart
- [ ] Simulate reboot: kill session, run `restart.sh` — verify skip-permissions is preserved from config

🤖 Generated with [Claude Code](https://claude.com/claude-code)