### PR TITLE
feat: add orchestrator plan-approval workflow

### DIFF
--- a/daemon/src/__tests__/plan-approval.test.ts
+++ b/daemon/src/__tests__/plan-approval.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Plan approval workflow tests — orchestrator plan submission, approval, and rejection.
+ *
+ * Tests the submit-plan, approve-plan, and reject-plan routes and their
+ * effect on task status and plan_status fields.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { openDatabase, _resetDbForTesting, query } from '../core/db.js';
+import { handleTaskQueueRoute } from '../api/task-queue.js';
+import { _setEvaluateTaskFnForTesting } from '../api/task-queue.js';
+
+const TEST_PORT = 19871;
+
+function request(
+  method: string,
+  urlPath: string,
+  body?: unknown,
+): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const opts: http.RequestOptions = {
+      host: '127.0.0.1',
+      port: TEST_PORT,
+      path: urlPath,
+      method,
+      timeout: 5000,
+      headers: {
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+        'Connection': 'close',
+      },
+    };
+    const r = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data, headers: res.headers }));
+    });
+    r.on('error', reject);
+    r.on('timeout', () => { r.destroy(); reject(new Error('timeout')); });
+    if (body !== undefined) r.write(JSON.stringify(body));
+    r.end();
+  });
+}
+
+let server: http.Server;
+let tmpDir: string;
+
+function setup(): Promise<void> {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kithkit-planapproval-'));
+  _resetDbForTesting();
+  openDatabase(tmpDir, path.join(tmpDir, 'test.db'));
+
+  // Disable retro evaluation for tests
+  _setEvaluateTaskFnForTesting(async () => {});
+
+  server = http.createServer((inReq, res) => {
+    const url = new URL(inReq.url ?? '/', `http://localhost:${TEST_PORT}`);
+    res.setHeader('X-Timestamp', new Date().toISOString());
+    handleTaskQueueRoute(inReq, res, url.pathname, url.searchParams)
+      .then((handled) => {
+        if (!handled) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Not found', timestamp: new Date().toISOString() }));
+        }
+      })
+      .catch((err) => {
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: String(err), timestamp: new Date().toISOString() }));
+        }
+      });
+  });
+
+  return new Promise<void>((resolve) => {
+    server.listen(TEST_PORT, '127.0.0.1', resolve);
+  });
+}
+
+function teardown(): Promise<void> {
+  _setEvaluateTaskFnForTesting(null);
+  return new Promise<void>((resolve) => {
+    _resetDbForTesting();
+    if (server?.listening) {
+      server.close(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        resolve();
+      });
+    } else {
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+      resolve();
+    }
+  });
+}
+
+/** Helper: create a task and return the parsed body. */
+async function createTask(overrides: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+  const res = await request('POST', '/api/orchestrator/tasks', {
+    title: 'Test task',
+    description: 'Do the thing',
+    ...overrides,
+  });
+  assert.equal(res.status, 201);
+  return JSON.parse(res.body);
+}
+
+/** Helper: advance a task to in_progress state. */
+async function advanceToInProgress(taskId: string): Promise<void> {
+  await request('PUT', `/api/orchestrator/tasks/${taskId}`, {
+    status: 'assigned', assignee: 'orchestrator',
+  });
+  await request('PUT', `/api/orchestrator/tasks/${taskId}`, {
+    status: 'in_progress',
+  });
+}
+
+describe('Plan Approval Workflow', { concurrency: 1 }, () => {
+
+  // ── submit-plan ────────────────────────────────────────────
+
+  describe('submit-plan', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('succeeds when task is in_progress', async () => {
+      const task = await createTask({ title: 'Plan me' });
+      await advanceToInProgress(task.id as string);
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'Step 1: Do X\nStep 2: Do Y\nStep 3: Verify',
+      });
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'awaiting_approval');
+      assert.equal(body.plan_status, 'submitted');
+      assert.ok(body.plan_submitted_at, 'should have plan_submitted_at');
+      assert.equal(body.plan, 'Step 1: Do X\nStep 2: Do Y\nStep 3: Verify');
+    });
+
+    it('fails when task is pending (not in_progress)', async () => {
+      const task = await createTask();
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'My plan',
+      });
+      assert.equal(res.status, 409);
+      const body = JSON.parse(res.body);
+      assert.ok(body.error.includes('in_progress'), `error: ${body.error}`);
+    });
+
+    it('fails when task is assigned (not in_progress)', async () => {
+      const task = await createTask();
+      await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'assigned', assignee: 'orchestrator',
+      });
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'My plan',
+      });
+      assert.equal(res.status, 409);
+    });
+
+    it('fails when plan field is missing', async () => {
+      const task = await createTask();
+      await advanceToInProgress(task.id as string);
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {});
+      assert.equal(res.status, 400);
+      const body = JSON.parse(res.body);
+      assert.ok(body.error.includes('plan'), `error: ${body.error}`);
+    });
+
+    it('logs activity on plan submission', async () => {
+      const task = await createTask();
+      await advanceToInProgress(task.id as string);
+
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'My detailed plan',
+      });
+
+      const actRes = await request('GET', `/api/orchestrator/tasks/${task.id}/activity`);
+      const actBody = JSON.parse(actRes.body);
+      const planLog = actBody.data.find(
+        (a: { stage: string }) => a.stage === 'plan_submitted',
+      );
+      assert.ok(planLog, 'should have logged plan_submitted activity');
+    });
+
+    it('returns 404 for nonexistent task', async () => {
+      const res = await request('POST', '/api/orchestrator/tasks/no-such-id/submit-plan', {
+        plan: 'A plan',
+      });
+      assert.equal(res.status, 404);
+    });
+  });
+
+  // ── approve-plan ───────────────────────────────────────────
+
+  describe('approve-plan', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('succeeds when awaiting_approval + plan_status=submitted', async () => {
+      const task = await createTask({ title: 'Approve me' });
+      await advanceToInProgress(task.id as string);
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'The plan',
+      });
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/approve-plan`, {});
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'in_progress');
+      assert.equal(body.plan_status, 'approved');
+      assert.ok(body.plan_approved_at, 'should have plan_approved_at');
+    });
+
+    it('fails when task is not awaiting_approval', async () => {
+      const task = await createTask();
+      await advanceToInProgress(task.id as string);
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/approve-plan`, {});
+      assert.equal(res.status, 409);
+      const body = JSON.parse(res.body);
+      assert.ok(body.error.includes('awaiting_approval'), `error: ${body.error}`);
+    });
+
+    it('fails when task is pending', async () => {
+      const task = await createTask();
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/approve-plan`, {});
+      assert.equal(res.status, 409);
+    });
+
+    it('logs activity on approval', async () => {
+      const task = await createTask();
+      await advanceToInProgress(task.id as string);
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'The plan',
+      });
+      await request('POST', `/api/orchestrator/tasks/${task.id}/approve-plan`, {});
+
+      const actRes = await request('GET', `/api/orchestrator/tasks/${task.id}/activity`);
+      const actBody = JSON.parse(actRes.body);
+      const approvalLog = actBody.data.find(
+        (a: { stage: string }) => a.stage === 'plan_approved',
+      );
+      assert.ok(approvalLog, 'should have logged plan_approved activity');
+    });
+
+    it('sends orchestrator notification on approval', async () => {
+      const task = await createTask();
+      await advanceToInProgress(task.id as string);
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'The plan',
+      });
+      await request('POST', `/api/orchestrator/tasks/${task.id}/approve-plan`, {});
+
+      const msgs = query<{ to_agent: string; body: string }>(
+        `SELECT to_agent, body FROM messages WHERE to_agent = 'orchestrator'`,
+      );
+      assert.ok(msgs.length > 0, 'should have sent message to orchestrator');
+      const approveMsg = msgs.find(m => m.body.includes('Plan approved'));
+      assert.ok(approveMsg, 'message body should mention plan approved');
+    });
+  });
+
+  // ── reject-plan ────────────────────────────────────────────
+
+  describe('reject-plan', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('succeeds with a reason', async () => {
+      const task = await createTask({ title: 'Reject me' });
+      await advanceToInProgress(task.id as string);
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'The plan',
+      });
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/reject-plan`, {
+        reason: 'Plan is too vague',
+      });
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'in_progress');
+      assert.equal(body.plan_status, 'rejected');
+      assert.equal(body.plan_rejected_reason, 'Plan is too vague');
+    });
+
+    it('succeeds without a reason, defaults to "No reason provided"', async () => {
+      const task = await createTask({ title: 'Reject no reason' });
+      await advanceToInProgress(task.id as string);
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'The plan',
+      });
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/reject-plan`, {});
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'in_progress');
+      assert.equal(body.plan_status, 'rejected');
+      assert.equal(body.plan_rejected_reason, 'No reason provided');
+    });
+
+    it('fails when task is not awaiting_approval', async () => {
+      const task = await createTask();
+      await advanceToInProgress(task.id as string);
+
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/reject-plan`, {
+        reason: 'Bad plan',
+      });
+      assert.equal(res.status, 409);
+      const body = JSON.parse(res.body);
+      assert.ok(body.error.includes('awaiting_approval'), `error: ${body.error}`);
+    });
+
+    it('logs activity on rejection with reason', async () => {
+      const task = await createTask();
+      await advanceToInProgress(task.id as string);
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'The plan',
+      });
+      await request('POST', `/api/orchestrator/tasks/${task.id}/reject-plan`, {
+        reason: 'Not detailed enough',
+      });
+
+      const actRes = await request('GET', `/api/orchestrator/tasks/${task.id}/activity`);
+      const actBody = JSON.parse(actRes.body);
+      const rejectionLog = actBody.data.find(
+        (a: { stage: string; message: string }) => a.stage === 'plan_rejected',
+      );
+      assert.ok(rejectionLog, 'should have logged plan_rejected activity');
+      assert.ok(rejectionLog.message.includes('Not detailed enough'), `message: ${rejectionLog.message}`);
+    });
+
+    it('sends orchestrator notification on rejection', async () => {
+      const task = await createTask();
+      await advanceToInProgress(task.id as string);
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'The plan',
+      });
+      await request('POST', `/api/orchestrator/tasks/${task.id}/reject-plan`, {
+        reason: 'Needs more detail',
+      });
+
+      const msgs = query<{ to_agent: string; body: string }>(
+        `SELECT to_agent, body FROM messages WHERE to_agent = 'orchestrator' AND body LIKE '%rejected%'`,
+      );
+      assert.ok(msgs.length > 0, 'should have sent rejection message to orchestrator');
+      assert.ok(msgs[0]!.body.includes('Needs more detail'), 'message should include rejection reason');
+    });
+  });
+
+  // ── State machine transitions ──────────────────────────────
+
+  describe('State machine transitions', () => {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('in_progress → awaiting_approval → in_progress (approved)', async () => {
+      const task = await createTask({ title: 'Full approval cycle' });
+
+      // Start at pending
+      let detail = JSON.parse((await request('GET', `/api/orchestrator/tasks/${task.id}`)).body);
+      assert.equal(detail.status, 'pending');
+
+      // Move to assigned then in_progress
+      await advanceToInProgress(task.id as string);
+      detail = JSON.parse((await request('GET', `/api/orchestrator/tasks/${task.id}`)).body);
+      assert.equal(detail.status, 'in_progress');
+
+      // Submit plan → awaiting_approval
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'My full plan',
+      });
+      detail = JSON.parse((await request('GET', `/api/orchestrator/tasks/${task.id}`)).body);
+      assert.equal(detail.status, 'awaiting_approval');
+      assert.equal(detail.plan_status, 'submitted');
+
+      // Approve → in_progress
+      await request('POST', `/api/orchestrator/tasks/${task.id}/approve-plan`, {});
+      detail = JSON.parse((await request('GET', `/api/orchestrator/tasks/${task.id}`)).body);
+      assert.equal(detail.status, 'in_progress');
+      assert.equal(detail.plan_status, 'approved');
+    });
+
+    it('in_progress → awaiting_approval → in_progress (rejected)', async () => {
+      const task = await createTask({ title: 'Full rejection cycle' });
+
+      await advanceToInProgress(task.id as string);
+
+      // Submit plan → awaiting_approval
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'My plan to be rejected',
+      });
+      let detail = JSON.parse((await request('GET', `/api/orchestrator/tasks/${task.id}`)).body);
+      assert.equal(detail.status, 'awaiting_approval');
+
+      // Reject → in_progress
+      await request('POST', `/api/orchestrator/tasks/${task.id}/reject-plan`, {
+        reason: 'Too vague',
+      });
+      detail = JSON.parse((await request('GET', `/api/orchestrator/tasks/${task.id}`)).body);
+      assert.equal(detail.status, 'in_progress');
+      assert.equal(detail.plan_status, 'rejected');
+      assert.equal(detail.plan_rejected_reason, 'Too vague');
+    });
+
+    it('awaiting_approval can be cancelled', async () => {
+      const task = await createTask({ title: 'Cancel while awaiting' });
+      await advanceToInProgress(task.id as string);
+
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'My plan',
+      });
+
+      // Cancel via PUT (using valid transition awaiting_approval → cancelled)
+      const res = await request('PUT', `/api/orchestrator/tasks/${task.id}`, {
+        status: 'cancelled',
+      });
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'cancelled');
+    });
+
+    it('awaiting_approval status is included in list filters', async () => {
+      const task = await createTask({ title: 'Awaiting list test' });
+      await advanceToInProgress(task.id as string);
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'My plan',
+      });
+
+      const res = await request('GET', '/api/orchestrator/tasks?status=awaiting_approval');
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.data.length, 1);
+      assert.equal(body.data[0].title, 'Awaiting list test');
+    });
+
+    it('cannot submit plan twice without re-entering in_progress', async () => {
+      const task = await createTask({ title: 'Double submit' });
+      await advanceToInProgress(task.id as string);
+      await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'First plan',
+      });
+
+      // Task is now awaiting_approval — cannot submit another plan
+      const res = await request('POST', `/api/orchestrator/tasks/${task.id}/submit-plan`, {
+        plan: 'Second plan',
+      });
+      assert.equal(res.status, 409, 'Should reject plan submission from awaiting_approval status');
+    });
+  });
+});

--- a/daemon/src/api/task-queue.ts
+++ b/daemon/src/api/task-queue.ts
@@ -2,18 +2,22 @@
  * Task Queue API — structured task management for orchestrator work.
  *
  * State machine: pending → assigned → in_progress → completed/failed/cancelled
+ *                                    in_progress → awaiting_approval → in_progress (approved/rejected)
  * Retry: failed → pending (increments retry_count)
  *
  * Routes:
- *   POST   /api/orchestrator/tasks              — Create a task
- *   GET    /api/orchestrator/tasks              — List tasks (filterable by status)
- *   GET    /api/orchestrator/tasks/:id          — Get task detail (+ workers + activity)
- *   PUT    /api/orchestrator/tasks/:id          — Update task (status, assignee, result)
- *   POST   /api/orchestrator/tasks/:id/activity — Post activity entry
- *   GET    /api/orchestrator/tasks/:id/activity — Get activity log (paginated)
- *   POST   /api/orchestrator/tasks/:id/workers  — Assign worker to task
- *   POST   /api/orchestrator/tasks/:id/retry    — Retry a failed task
- *   POST   /api/orchestrator/tasks/:id/cancel   — Cancel a pending/in_progress task
+ *   POST   /api/orchestrator/tasks                       — Create a task
+ *   GET    /api/orchestrator/tasks                       — List tasks (filterable by status)
+ *   GET    /api/orchestrator/tasks/:id                   — Get task detail (+ workers + activity)
+ *   PUT    /api/orchestrator/tasks/:id                   — Update task (status, assignee, result)
+ *   POST   /api/orchestrator/tasks/:id/activity          — Post activity entry
+ *   GET    /api/orchestrator/tasks/:id/activity          — Get activity log (paginated)
+ *   POST   /api/orchestrator/tasks/:id/workers           — Assign worker to task
+ *   POST   /api/orchestrator/tasks/:id/retry             — Retry a failed task
+ *   POST   /api/orchestrator/tasks/:id/cancel            — Cancel a pending/in_progress task
+ *   POST   /api/orchestrator/tasks/:id/submit-plan       — Submit plan for human approval
+ *   POST   /api/orchestrator/tasks/:id/approve-plan      — Approve a submitted plan
+ *   POST   /api/orchestrator/tasks/:id/reject-plan       — Reject a submitted plan
  */
 
 import type http from 'node:http';
@@ -35,7 +39,7 @@ const log = createLogger('task-queue');
 
 // ── Types ────────────────────────────────────────────────────
 
-type TaskStatus = 'pending' | 'assigned' | 'in_progress' | 'completed' | 'failed' | 'cancelled';
+type TaskStatus = 'pending' | 'assigned' | 'in_progress' | 'awaiting_approval' | 'completed' | 'failed' | 'cancelled';
 type ActivityType = 'progress' | 'note';
 
 type TaskOutcome = 'success' | 'partial' | 'failed' | 'unknown';
@@ -56,6 +60,11 @@ interface OrchestratorTask {
   timeout_seconds: number | null;
   outcome: TaskOutcome | null;
   outcome_notes: string | null;
+  plan: string | null;
+  plan_status: 'submitted' | 'approved' | 'rejected' | null;
+  plan_submitted_at: string | null;
+  plan_approved_at: string | null;
+  plan_rejected_reason: string | null;
   created_at: string;
   assigned_at: string | null;
   started_at: string | null;
@@ -82,7 +91,7 @@ interface TaskActivity {
 
 // ── Constants ────────────────────────────────────────────────
 
-const VALID_STATUSES: readonly TaskStatus[] = ['pending', 'assigned', 'in_progress', 'completed', 'failed', 'cancelled'];
+const VALID_STATUSES: readonly TaskStatus[] = ['pending', 'assigned', 'in_progress', 'awaiting_approval', 'completed', 'failed', 'cancelled'];
 const TERMINAL_STATUSES: readonly TaskStatus[] = ['completed', 'failed', 'cancelled'];
 const VALID_ACTIVITY_TYPES: readonly ActivityType[] = ['progress', 'note'];
 
@@ -92,7 +101,8 @@ const VALID_ACTIVITY_TYPES: readonly ActivityType[] = ['progress', 'note'];
 const VALID_TRANSITIONS: Record<TaskStatus, readonly TaskStatus[]> = {
   pending: ['assigned', 'failed', 'cancelled'],
   assigned: ['in_progress', 'failed', 'pending', 'cancelled'],
-  in_progress: ['completed', 'failed', 'cancelled'],
+  in_progress: ['completed', 'failed', 'cancelled', 'awaiting_approval'],
+  awaiting_approval: ['in_progress', 'cancelled'],
   completed: [],
   failed: ['pending'],  // retry: failed → pending
   cancelled: [],
@@ -111,6 +121,7 @@ function validateStatusAssignee(status: TaskStatus, assignee: string | null): st
   if (status === 'assigned' && !assignee) {
     return 'assigned tasks require a non-null assignee';
   }
+  // awaiting_approval keeps its assignee (like in_progress) — no validation needed
   return null;
 }
 
@@ -446,6 +457,166 @@ export async function handleTaskQueueRoute(
       return true;
     }
 
+    // POST /api/orchestrator/tasks/:id/submit-plan — submit plan for human approval
+    if (subpath === '/submit-plan' && method === 'POST') {
+      const task = getTask(taskId);
+      if (!task) {
+        json(res, 404, withTimestamp({ error: 'Task not found' }));
+        return true;
+      }
+
+      if (task.status !== 'in_progress') {
+        json(res, 409, withTimestamp({ error: `Can only submit a plan for in_progress tasks, current status: ${task.status}` }));
+        return true;
+      }
+
+      const body = await parseBody(req);
+
+      if (!body.plan || typeof body.plan !== 'string') {
+        json(res, 400, withTimestamp({ error: 'plan is required and must be a string' }));
+        return true;
+      }
+
+      const ts = now();
+
+      exec(
+        `UPDATE orchestrator_tasks SET plan = ?, plan_status = 'submitted', plan_submitted_at = ?, status = 'awaiting_approval', updated_at = ? WHERE id = ?`,
+        body.plan, ts, ts, taskId,
+      );
+
+      exec(
+        `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+         VALUES (?, 'orchestrator', 'note', 'plan_submitted', 'Plan submitted for human approval', ?)`,
+        taskId, ts,
+      );
+
+      // Notify comms via DB message
+      const planPreview = (body.plan as string).slice(0, 500);
+      const notifyBody = `[plan approval needed] Task "${task.title.slice(0, 80)}" has submitted a plan for review.\n\nPlan:\n${planPreview}${(body.plan as string).length > 500 ? '\n...(truncated)' : ''}\n\nApprove: curl -s -X POST 'http://localhost:3847/api/orchestrator/tasks/${taskId}/approve-plan' -H 'Content-Type: application/json' -d '{}'\nReject: curl -s -X POST 'http://localhost:3847/api/orchestrator/tasks/${taskId}/reject-plan' -H 'Content-Type: application/json' -d '{"reason":"..."}'`;
+
+      try {
+        exec(
+          `INSERT INTO messages (from_agent, to_agent, type, body, created_at) VALUES ('daemon', 'comms', 'task', ?, ?)`,
+          notifyBody, ts,
+        );
+      } catch (err) {
+        log.warn('Failed to insert plan approval message to comms', { taskId, error: String(err) });
+      }
+
+      // Also inject directly into comms tmux session for immediate visibility
+      injectMessage('comms', notifyBody);
+
+      const updated = getTask(taskId)!;
+      log.info('Plan submitted for approval', { taskId, title: task.title });
+      json(res, 200, withTimestamp(updated));
+      return true;
+    }
+
+    // POST /api/orchestrator/tasks/:id/approve-plan — approve a submitted plan
+    if (subpath === '/approve-plan' && method === 'POST') {
+      const task = getTask(taskId);
+      if (!task) {
+        json(res, 404, withTimestamp({ error: 'Task not found' }));
+        return true;
+      }
+
+      if (task.status !== 'awaiting_approval') {
+        json(res, 409, withTimestamp({ error: `Can only approve plans for awaiting_approval tasks, current status: ${task.status}` }));
+        return true;
+      }
+
+      if (task.plan_status !== 'submitted') {
+        json(res, 409, withTimestamp({ error: `Can only approve tasks with plan_status=submitted, current plan_status: ${task.plan_status}` }));
+        return true;
+      }
+
+      const ts = now();
+
+      exec(
+        `UPDATE orchestrator_tasks SET plan_status = 'approved', plan_approved_at = ?, status = 'in_progress', updated_at = ? WHERE id = ?`,
+        ts, ts, taskId,
+      );
+
+      exec(
+        `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+         VALUES (?, 'daemon', 'note', 'plan_approved', 'Plan approved — resuming execution', ?)`,
+        taskId, ts,
+      );
+
+      // Notify orchestrator
+      const approveMsg = `[System] Plan approved for task ${taskId}. Resume execution.`;
+      try {
+        exec(
+          `INSERT INTO messages (from_agent, to_agent, type, body, created_at) VALUES ('daemon', 'orchestrator', 'task', ?, ?)`,
+          approveMsg, ts,
+        );
+      } catch (err) {
+        log.warn('Failed to insert plan approval notification to orchestrator', { taskId, error: String(err) });
+      }
+
+      injectMessage('orchestrator', approveMsg);
+
+      const updated = getTask(taskId)!;
+      log.info('Plan approved', { taskId, title: task.title });
+      json(res, 200, withTimestamp(updated));
+      return true;
+    }
+
+    // POST /api/orchestrator/tasks/:id/reject-plan — reject a submitted plan
+    if (subpath === '/reject-plan' && method === 'POST') {
+      const task = getTask(taskId);
+      if (!task) {
+        json(res, 404, withTimestamp({ error: 'Task not found' }));
+        return true;
+      }
+
+      if (task.status !== 'awaiting_approval') {
+        json(res, 409, withTimestamp({ error: `Can only reject plans for awaiting_approval tasks, current status: ${task.status}` }));
+        return true;
+      }
+
+      if (task.plan_status !== 'submitted') {
+        json(res, 409, withTimestamp({ error: `Can only reject tasks with plan_status=submitted, current plan_status: ${task.plan_status}` }));
+        return true;
+      }
+
+      const body = await parseBody(req);
+      const reason = typeof body.reason === 'string' && body.reason.trim()
+        ? body.reason.trim()
+        : 'No reason provided';
+
+      const ts = now();
+
+      exec(
+        `UPDATE orchestrator_tasks SET plan_status = 'rejected', plan_rejected_reason = ?, status = 'in_progress', updated_at = ? WHERE id = ?`,
+        reason, ts, taskId,
+      );
+
+      exec(
+        `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+         VALUES (?, 'daemon', 'note', 'plan_rejected', ?, ?)`,
+        taskId, `Plan rejected. Reason: ${reason}`, ts,
+      );
+
+      // Notify orchestrator
+      const rejectMsg = `[System] Plan rejected for task ${taskId}. Reason: ${reason}. Revise and resubmit.`;
+      try {
+        exec(
+          `INSERT INTO messages (from_agent, to_agent, type, body, created_at) VALUES ('daemon', 'orchestrator', 'task', ?, ?)`,
+          rejectMsg, ts,
+        );
+      } catch (err) {
+        log.warn('Failed to insert plan rejection notification to orchestrator', { taskId, error: String(err) });
+      }
+
+      injectMessage('orchestrator', rejectMsg);
+
+      const updated = getTask(taskId)!;
+      log.info('Plan rejected', { taskId, title: task.title, reason });
+      json(res, 200, withTimestamp(updated));
+      return true;
+    }
+
     // GET /api/orchestrator/tasks/:id — get task detail
     if (!subpath && method === 'GET') {
       const task = getTask(taskId);
@@ -474,6 +645,7 @@ export async function handleTaskQueueRoute(
         return true;
       }
 
+      // awaiting_approval is not terminal — it can transition back to in_progress
       if (TERMINAL_STATUSES.includes(task.status as TaskStatus)) {
         json(res, 409, withTimestamp({ error: `Cannot update ${task.status} task` }));
         return true;
@@ -561,6 +733,9 @@ export async function handleTaskQueueRoute(
       }
       if (body.outcome_notes !== undefined) {
         updates.outcome_notes = typeof body.outcome_notes === 'string' ? body.outcome_notes : null;
+      }
+      if (body.plan !== undefined) {
+        updates.plan = typeof body.plan === 'string' ? body.plan : null;
       }
 
       // Validate the final status/assignee combination

--- a/daemon/src/api/task-queue.ts
+++ b/daemon/src/api/task-queue.ts
@@ -23,7 +23,7 @@
 import type http from 'node:http';
 import { randomUUID } from 'node:crypto';
 import { json, withTimestamp, parseBody } from './helpers.js';
-import { query, exec, get } from '../core/db.js';
+import { query, exec, get, getDatabase } from '../core/db.js';
 import { injectMessage } from '../agents/tmux.js';
 import { createLogger } from '../core/logger.js';
 import { storeMemoryInternal } from './memory.js';
@@ -479,16 +479,18 @@ export async function handleTaskQueueRoute(
 
       const ts = now();
 
-      exec(
-        `UPDATE orchestrator_tasks SET plan = ?, plan_status = 'submitted', plan_submitted_at = ?, status = 'awaiting_approval', updated_at = ? WHERE id = ?`,
-        body.plan, ts, ts, taskId,
-      );
+      getDatabase().transaction(() => {
+        exec(
+          `UPDATE orchestrator_tasks SET plan = ?, plan_status = 'submitted', plan_submitted_at = ?, status = 'awaiting_approval', updated_at = ? WHERE id = ?`,
+          body.plan, ts, ts, taskId,
+        );
 
-      exec(
-        `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
-         VALUES (?, 'orchestrator', 'note', 'plan_submitted', 'Plan submitted for human approval', ?)`,
-        taskId, ts,
-      );
+        exec(
+          `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+           VALUES (?, 'orchestrator', 'note', 'plan_submitted', 'Plan submitted for human approval', ?)`,
+          taskId, ts,
+        );
+      })();
 
       // Notify comms via DB message
       const planPreview = (body.plan as string).slice(0, 500);
@@ -504,7 +506,11 @@ export async function handleTaskQueueRoute(
       }
 
       // Also inject directly into comms tmux session for immediate visibility
-      injectMessage('comms', notifyBody);
+      try {
+        injectMessage('comms', notifyBody);
+      } catch (e) {
+        log.warn('Failed to inject plan submission notification to comms', { taskId, error: String(e) });
+      }
 
       const updated = getTask(taskId)!;
       log.info('Plan submitted for approval', { taskId, title: task.title });
@@ -532,16 +538,18 @@ export async function handleTaskQueueRoute(
 
       const ts = now();
 
-      exec(
-        `UPDATE orchestrator_tasks SET plan_status = 'approved', plan_approved_at = ?, status = 'in_progress', updated_at = ? WHERE id = ?`,
-        ts, ts, taskId,
-      );
+      getDatabase().transaction(() => {
+        exec(
+          `UPDATE orchestrator_tasks SET plan_status = 'approved', plan_approved_at = ?, status = 'in_progress', updated_at = ? WHERE id = ?`,
+          ts, ts, taskId,
+        );
 
-      exec(
-        `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
-         VALUES (?, 'daemon', 'note', 'plan_approved', 'Plan approved — resuming execution', ?)`,
-        taskId, ts,
-      );
+        exec(
+          `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+           VALUES (?, 'daemon', 'note', 'plan_approved', 'Plan approved — resuming execution', ?)`,
+          taskId, ts,
+        );
+      })();
 
       // Notify orchestrator
       const approveMsg = `[System] Plan approved for task ${taskId}. Resume execution.`;
@@ -554,7 +562,11 @@ export async function handleTaskQueueRoute(
         log.warn('Failed to insert plan approval notification to orchestrator', { taskId, error: String(err) });
       }
 
-      injectMessage('orchestrator', approveMsg);
+      try {
+        injectMessage('orchestrator', approveMsg);
+      } catch (e) {
+        log.warn('Failed to inject plan approval notification to orchestrator', { taskId, error: String(e) });
+      }
 
       const updated = getTask(taskId)!;
       log.info('Plan approved', { taskId, title: task.title });
@@ -587,16 +599,18 @@ export async function handleTaskQueueRoute(
 
       const ts = now();
 
-      exec(
-        `UPDATE orchestrator_tasks SET plan_status = 'rejected', plan_rejected_reason = ?, status = 'in_progress', updated_at = ? WHERE id = ?`,
-        reason, ts, taskId,
-      );
+      getDatabase().transaction(() => {
+        exec(
+          `UPDATE orchestrator_tasks SET plan_status = 'rejected', plan_rejected_reason = ?, status = 'in_progress', updated_at = ? WHERE id = ?`,
+          reason, ts, taskId,
+        );
 
-      exec(
-        `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
-         VALUES (?, 'daemon', 'note', 'plan_rejected', ?, ?)`,
-        taskId, `Plan rejected. Reason: ${reason}`, ts,
-      );
+        exec(
+          `INSERT INTO orchestrator_task_activity (task_id, agent, type, stage, message, created_at)
+           VALUES (?, 'daemon', 'note', 'plan_rejected', ?, ?)`,
+          taskId, `Plan rejected. Reason: ${reason}`, ts,
+        );
+      })();
 
       // Notify orchestrator
       const rejectMsg = `[System] Plan rejected for task ${taskId}. Reason: ${reason}. Revise and resubmit.`;
@@ -609,7 +623,11 @@ export async function handleTaskQueueRoute(
         log.warn('Failed to insert plan rejection notification to orchestrator', { taskId, error: String(err) });
       }
 
-      injectMessage('orchestrator', rejectMsg);
+      try {
+        injectMessage('orchestrator', rejectMsg);
+      } catch (e) {
+        log.warn('Failed to inject plan rejection notification to orchestrator', { taskId, error: String(e) });
+      }
 
       const updated = getTask(taskId)!;
       log.info('Plan rejected', { taskId, title: task.title, reason });
@@ -735,6 +753,11 @@ export async function handleTaskQueueRoute(
         updates.outcome_notes = typeof body.outcome_notes === 'string' ? body.outcome_notes : null;
       }
       if (body.plan !== undefined) {
+        // Block plan mutation while awaiting approval — what was approved must match what executes
+        if (task.plan_status === 'submitted') {
+          json(res, 409, withTimestamp({ error: 'Cannot modify plan while awaiting approval. Reject the current plan first.' }));
+          return true;
+        }
         updates.plan = typeof body.plan === 'string' ? body.plan : null;
       }
 

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -499,10 +499,14 @@ async function run(config: Record<string, unknown>): Promise<void> {
     const pendingWhileActiveCount = pendingWhileActive[0]?.count ?? 0;
     if (pendingWhileActiveCount > 0) {
       log.debug('Pending tasks queued while Claude is active — injecting soft nudge', { pendingWhileActiveCount });
-      injectMessage(
-        'orchestrator',
-        `[System] ${pendingWhileActiveCount} pending task(s) in queue. Check GET /api/orchestrator/tasks?status=pending when your current work is done.`,
-      );
+      try {
+        injectMessage(
+          'orchestrator',
+          `[System] ${pendingWhileActiveCount} pending task(s) in queue. Check GET /api/orchestrator/tasks?status=pending when your current work is done.`,
+        );
+      } catch (e) {
+        log.warn('Failed to inject pending-tasks nudge to orchestrator', { error: String(e) });
+      }
     }
 
     return;

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -332,6 +332,28 @@ async function run(config: Record<string, unknown>): Promise<void> {
   // This catches stale/zombie tasks from a dead orchestrator early.
   checkTaskTimeouts();
 
+  // Check for stale plan approvals
+  const fullConfig = loadConfig();
+  const slaMinutes = (fullConfig as unknown as Record<string, Record<string, unknown>>)?.orchestrator?.plan_review_sla_minutes as number ?? 10;
+  const slaThreshold = new Date(Date.now() - slaMinutes * 60 * 1000).toISOString();
+  const stalePlans = query<{ id: string; title: string; plan_submitted_at: string }>(
+    `SELECT id, title, plan_submitted_at FROM orchestrator_tasks
+     WHERE status = 'awaiting_approval' AND plan_status = 'submitted'
+     AND plan_submitted_at < ?`,
+    slaThreshold,
+  );
+
+  if (stalePlans.length > 0) {
+    for (const plan of stalePlans) {
+      const waitMinutes = Math.round((Date.now() - new Date(plan.plan_submitted_at).getTime()) / 60000);
+      const nudgeMsg = `[plan review needed] Task "${plan.title.slice(0, 80)}" has a plan waiting ${waitMinutes}m for approval (SLA: ${slaMinutes}m).\n` +
+        `Approve: curl -s -X POST 'http://localhost:${fullConfig.daemon.port}/api/orchestrator/tasks/${plan.id}/approve-plan' -H 'Content-Type: application/json' -d '{}'\n` +
+        `Reject: curl -s -X POST 'http://localhost:${fullConfig.daemon.port}/api/orchestrator/tasks/${plan.id}/reject-plan' -H 'Content-Type: application/json' -d '{"reason":"..."}'`;
+      injectMessage('comms', nudgeMsg);
+    }
+    log.info('Nudged comms about stale plan approvals', { count: stalePlans.length });
+  }
+
   // Detect orphaned tasks from a previous orchestrator instance.
   // Runs unconditionally — even when the orchestrator IS alive — because the new
   // orchestrator's liveness masks the dead one's abandoned tasks.

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -528,7 +528,12 @@ async function run(config: Record<string, unknown>): Promise<void> {
   if (contextUsed !== null && contextUsed >= CONTEXT_THRESHOLD_PCT) {
     const reason = `context at ${contextUsed}% — save any pending work state to the daemon (POST /api/messages) and exit. The daemon will respawn you with that context.`;
     log.warn('Orchestrator context backstop triggered', { contextUsed });
-    const injected = injectMessage('orchestrator', buildShutdownPrompt(reason));
+    let injected = false;
+    try {
+      injected = injectMessage('orchestrator', buildShutdownPrompt(reason));
+    } catch (e) {
+      log.warn('Failed to inject context shutdown nudge to orchestrator', { error: String(e) });
+    }
     if (injected) {
       shutdownNudgedAt = Date.now();
       shutdownReason = `context exhaustion (${contextUsed}%)`;
@@ -592,7 +597,12 @@ async function run(config: Record<string, unknown>): Promise<void> {
       ? `You have 1 pending task: "${taskTitle}" — check GET /api/orchestrator/tasks?status=pending`
       : `You have ${pendingTaskCount} pending tasks — check GET /api/orchestrator/tasks?status=pending`;
     log.info('Orchestrator idle but has pending tasks — waking instead of shutdown', { pendingTaskCount });
-    const injected = injectMessage('orchestrator', wakeMsg);
+    let injected = false;
+    try {
+      injected = injectMessage('orchestrator', wakeMsg);
+    } catch (e) {
+      log.warn('Failed to inject pending task wake to orchestrator', { error: String(e) });
+    }
     if (injected) {
       // Touch last_activity so we don't immediately re-trigger
       update('agents', 'orchestrator', {
@@ -610,7 +620,12 @@ async function run(config: Record<string, unknown>): Promise<void> {
 
   const reason = `idle for ${Math.round(idleMs / 60000)} minutes — Claude process not running, no pending work`;
   log.info('Orchestrator idle — sending shutdown nudge', { idleMinutes: Math.round(idleMs / 60000) });
-  const injected = injectMessage('orchestrator', buildShutdownPrompt(reason));
+  let injected = false;
+  try {
+    injected = injectMessage('orchestrator', buildShutdownPrompt(reason));
+  } catch (e) {
+    log.warn('Failed to inject idle shutdown nudge to orchestrator', { error: String(e) });
+  }
 
   if (injected) {
     shutdownNudgedAt = Date.now();

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -71,6 +71,11 @@ function writePostMortem(reason: string): void {
 }
 
 const DEFAULT_IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const DEFAULT_SLA_MINUTES = 30;
+const SLA_NOTIFY_COOLDOWN_MS = 15 * 60 * 1000; // 15 minutes between nudges per task
+
+// Track last SLA notification time per task ID (in-memory; resets on daemon restart, which is acceptable)
+const slaLastNotifiedAt = new Map<string, number>();
 const CONTEXT_THRESHOLD_PCT = 65; // Daemon backstop — orchestrator self-restarts at 50%
 const CONTEXT_STALE_SECONDS = 600; // Ignore context data older than 10 min
 const GRACE_PERIOD_MS = 60 * 1000; // 60 seconds to exit after nudge
@@ -334,7 +339,8 @@ async function run(config: Record<string, unknown>): Promise<void> {
 
   // Check for stale plan approvals
   const fullConfig = loadConfig();
-  const slaMinutes = (fullConfig as unknown as Record<string, Record<string, unknown>>)?.orchestrator?.plan_review_sla_minutes as number ?? 10;
+  const rawSla = (fullConfig as unknown as Record<string, Record<string, unknown>>)?.orchestrator?.plan_review_sla_minutes;
+  const slaMinutes = typeof rawSla === 'number' ? rawSla : DEFAULT_SLA_MINUTES;
   const slaThreshold = new Date(Date.now() - slaMinutes * 60 * 1000).toISOString();
   const stalePlans = query<{ id: string; title: string; plan_submitted_at: string }>(
     `SELECT id, title, plan_submitted_at FROM orchestrator_tasks
@@ -344,14 +350,25 @@ async function run(config: Record<string, unknown>): Promise<void> {
   );
 
   if (stalePlans.length > 0) {
+    const now = Date.now();
+    let nudgeCount = 0;
     for (const plan of stalePlans) {
-      const waitMinutes = Math.round((Date.now() - new Date(plan.plan_submitted_at).getTime()) / 60000);
+      const lastNotified = slaLastNotifiedAt.get(plan.id) ?? 0;
+      if (now - lastNotified < SLA_NOTIFY_COOLDOWN_MS) {
+        log.debug('Skipping SLA nudge — within cooldown', { taskId: plan.id, cooldownMs: SLA_NOTIFY_COOLDOWN_MS });
+        continue;
+      }
+      const waitMinutes = Math.round((now - new Date(plan.plan_submitted_at).getTime()) / 60000);
       const nudgeMsg = `[plan review needed] Task "${plan.title.slice(0, 80)}" has a plan waiting ${waitMinutes}m for approval (SLA: ${slaMinutes}m).\n` +
         `Approve: curl -s -X POST 'http://localhost:${fullConfig.daemon.port}/api/orchestrator/tasks/${plan.id}/approve-plan' -H 'Content-Type: application/json' -d '{}'\n` +
         `Reject: curl -s -X POST 'http://localhost:${fullConfig.daemon.port}/api/orchestrator/tasks/${plan.id}/reject-plan' -H 'Content-Type: application/json' -d '{"reason":"..."}'`;
       injectMessage('comms', nudgeMsg);
+      slaLastNotifiedAt.set(plan.id, now);
+      nudgeCount++;
     }
-    log.info('Nudged comms about stale plan approvals', { count: stalePlans.length });
+    if (nudgeCount > 0) {
+      log.info('Nudged comms about stale plan approvals', { count: nudgeCount });
+    }
   }
 
   // Detect orphaned tasks from a previous orchestrator instance.

--- a/daemon/src/automation/tasks/orchestrator-idle.ts
+++ b/daemon/src/automation/tasks/orchestrator-idle.ts
@@ -362,7 +362,11 @@ async function run(config: Record<string, unknown>): Promise<void> {
       const nudgeMsg = `[plan review needed] Task "${plan.title.slice(0, 80)}" has a plan waiting ${waitMinutes}m for approval (SLA: ${slaMinutes}m).\n` +
         `Approve: curl -s -X POST 'http://localhost:${fullConfig.daemon.port}/api/orchestrator/tasks/${plan.id}/approve-plan' -H 'Content-Type: application/json' -d '{}'\n` +
         `Reject: curl -s -X POST 'http://localhost:${fullConfig.daemon.port}/api/orchestrator/tasks/${plan.id}/reject-plan' -H 'Content-Type: application/json' -d '{"reason":"..."}'`;
-      injectMessage('comms', nudgeMsg);
+      try {
+        injectMessage('comms', nudgeMsg);
+      } catch (e) {
+        log.warn('Failed to inject SLA notification to comms', { taskId: plan.id, error: String(e) });
+      }
       slaLastNotifiedAt.set(plan.id, now);
       nudgeCount++;
     }

--- a/daemon/src/core/migrations/018-plan-approval.sql
+++ b/daemon/src/core/migrations/018-plan-approval.sql
@@ -1,0 +1,7 @@
+-- Plan approval workflow for orchestrator tasks.
+-- Allows orchestrators to submit plans for human approval before executing work.
+--safe-alter: orchestrator_tasks ADD COLUMN plan TEXT
+--safe-alter: orchestrator_tasks ADD COLUMN plan_status TEXT DEFAULT NULL
+--safe-alter: orchestrator_tasks ADD COLUMN plan_submitted_at TEXT
+--safe-alter: orchestrator_tasks ADD COLUMN plan_approved_at TEXT
+--safe-alter: orchestrator_tasks ADD COLUMN plan_rejected_reason TEXT

--- a/kithkit.defaults.yaml
+++ b/kithkit.defaults.yaml
@@ -107,6 +107,9 @@ scheduler:
           tool-usage: null
           communication: null
 
+orchestrator:
+  plan_review_sla_minutes: 10
+
 security:
   rate_limits:
     incoming_max_per_minute: 5

--- a/templates/config/kithkit.defaults.yaml
+++ b/templates/config/kithkit.defaults.yaml
@@ -51,6 +51,9 @@ scheduler:
       config:
         requires_session: true
 
+orchestrator:
+  plan_review_sla_minutes: 10
+
 security:
   rate_limits:
     incoming_max_per_minute: 5


### PR DESCRIPTION
## Summary

- **Plan-approval gate for orchestrator tasks**: Before executing work, the orchestrator can submit a plan for human review via `POST /api/orchestrator/tasks/:id/submit-plan`. The task enters `awaiting_approval` status and comms is notified immediately with approve/reject curl commands. Human approves via `POST /approve-plan` or rejects via `POST /reject-plan` (with optional reason), both of which transition the task back to `in_progress` and notify the orchestrator.

- **SLA nudge for stale plans**: `orchestrator-idle` now checks for tasks stuck in `awaiting_approval` past the configurable SLA (`orchestrator.plan_review_sla_minutes`, default 10 minutes). Each tick it injects a reminder to comms with the wait time and approve/reject commands.

- **Message router hardened against wrong-task auto-completion**: Auto-complete on orchestrator result messages requires an exact `metadata.task_id` match. No fallback query — missing or unmatched task IDs are logged as warnings only. (This was already in place on upstream; no code changes needed.)

- **Migration 018**: Adds `plan`, `plan_status`, `plan_submitted_at`, `plan_approved_at`, and `plan_rejected_reason` columns to `orchestrator_tasks` via safe-alter directives.

## State machine

```
pending → assigned → in_progress → completed/failed/cancelled
                         ↕
                  awaiting_approval
```

`awaiting_approval` transitions: `in_progress → awaiting_approval → in_progress` (approved or rejected), or `awaiting_approval → cancelled`.

## Test plan

- [x] `submit-plan` succeeds when task is `in_progress`
- [x] `submit-plan` fails when task is not `in_progress` (pending, assigned, awaiting_approval)
- [x] `submit-plan` fails when `plan` field is missing
- [x] `approve-plan` succeeds when `awaiting_approval` + `plan_status=submitted`
- [x] `approve-plan` fails when not `awaiting_approval`
- [x] `reject-plan` succeeds with reason
- [x] `reject-plan` succeeds without reason (defaults to "No reason provided")
- [x] `reject-plan` fails when not `awaiting_approval`
- [x] Full cycle: `in_progress → awaiting_approval → in_progress` (approved)
- [x] Full cycle: `in_progress → awaiting_approval → in_progress` (rejected)
- [x] `awaiting_approval` can be cancelled via PUT
- [x] `awaiting_approval` appears in status list filters
- [x] Cannot submit plan twice without re-entering `in_progress`
- [x] Activity log entries created for submit/approve/reject
- [x] Orchestrator notified on approve and reject
- [x] All 37 existing task-queue tests continue to pass (21 new tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)