### PR TITLE
fix: update remaining .claude/ paths to .kithkit/ post-migration

### DIFF
--- a/daemon/src/automation/tasks/kkit-reflection.ts
+++ b/daemon/src/automation/tasks/kkit-reflection.ts
@@ -18,7 +18,7 @@ import type { Scheduler } from '../scheduler.js';
 const log = createLogger('kkit-reflection');
 
 /** Base path for skill reference files, relative to project root. */
-export const SKILLS_REL_PATH = '.claude/skills';
+export const SKILLS_REL_PATH = '.kithkit/skills';
 
 // ── Config ──────────────────────────────────────────────────
 

--- a/daemon/src/extensions/comms/adapters/telegram.ts
+++ b/daemon/src/extensions/comms/adapters/telegram.ts
@@ -35,9 +35,9 @@ import { markdownToTelegramHtml, hasMarkdownPatterns, hasHtmlTags } from './tele
 
 const log = createLogger('telegram');
 
-const MEDIA_DIR_REL = '.claude/state/telegram-media';
-const REPLY_CHAT_ID_REL = '.claude/state/reply-chat-id.txt';
-const CHANNEL_FILE_REL = '.claude/state/channel.txt';
+const MEDIA_DIR_REL = '.kithkit/state/telegram-media';
+const REPLY_CHAT_ID_REL = '.kithkit/state/reply-chat-id.txt';
+const CHANNEL_FILE_REL = '.kithkit/state/channel.txt';
 
 // ── Keychain helpers ─────────────────────────────────────────
 
@@ -592,7 +592,7 @@ function registerAgentTiers(): void {
   }
 
   // Load 3rd-party-senders.json for approved/pending third-party senders
-  const thirdParty = loadJsonFile<Array<{ id?: string; channels?: Record<string, unknown> }>>('.claude/state/3rd-party-senders.json') ?? [];
+  const thirdParty = loadJsonFile<Array<{ id?: string; channels?: Record<string, unknown> }>>('.kithkit/state/3rd-party-senders.json') ?? [];
 
   const approvedIds = new Set<string>();
   const pendingIds = new Set<string>();

--- a/daemon/src/extensions/comms/channel-router.ts
+++ b/daemon/src/extensions/comms/channel-router.ts
@@ -37,7 +37,7 @@ let _telegramAdapter: (ChannelAdapter & { startTyping?(): Promise<void>; stopTyp
 let _voicePendingCallback: MessageHandler | null = null;
 let _responseHook: MessageHandler | null = null;
 
-const CHANNEL_FILE_REL = '.claude/state/channel.txt';
+const CHANNEL_FILE_REL = '.kithkit/state/channel.txt';
 
 // ── Channel file management ──────────────────────────────────
 

--- a/daemon/src/extensions/comms/network/sdk-bridge.ts
+++ b/daemon/src/extensions/comms/network/sdk-bridge.ts
@@ -82,7 +82,7 @@ export async function initNetworkSDK(config: Record<string, unknown>): Promise<b
       username: agentName,
       privateKey: privateKeyBuffer,
       endpoint: networkConfig.endpoint,
-      dataDir: '.claude/state/network-cache',
+      dataDir: '.kithkit/state/network-cache',
       heartbeatInterval: networkConfig.heartbeat_interval ?? 300_000,
     };
 

--- a/scripts/tmux-context-status.sh
+++ b/scripts/tmux-context-status.sh
@@ -8,7 +8,7 @@
 #   C:33%          (only comms)
 #   ctx:--         (no data or stale)
 
-STATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.claude/state"
+STATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.kithkit/state"
 STALE_SECONDS=300  # Consider data stale after 5 minutes
 
 now=$(date +%s)


### PR DESCRIPTION
## Summary

Five files still referenced `.claude/state/` after the `.claude/` → `.kithkit/` migration (PR #234). This PR completes the migration by updating those stale paths:

- **`daemon/src/automation/tasks/kkit-reflection.ts`** — `SKILLS_REL_PATH` changed from `.claude/skills` to `.kithkit/skills`
- **`daemon/src/extensions/comms/network/sdk-bridge.ts`** — SDK `dataDir` changed from `.claude/state/network-cache` to `.kithkit/state/network-cache`
- **`daemon/src/extensions/comms/channel-router.ts`** — `CHANNEL_FILE_REL` changed from `.claude/state/channel.txt` to `.kithkit/state/channel.txt`
- **`daemon/src/extensions/comms/adapters/telegram.ts`** — `MEDIA_DIR_REL`, `REPLY_CHAT_ID_REL`, `CHANNEL_FILE_REL`, and the `3rd-party-senders.json` path all updated from `.claude/state/` to `.kithkit/state/`
- **`scripts/tmux-context-status.sh`** — `STATE_DIR` updated from `.claude/state` to `.kithkit/state`

Files intentionally left unchanged: `context-watchdog.ts` (references `.claude/settings.json` which Claude Code reads from `.claude/`) and test files under `self-improvement/__tests__/` (test hook paths at `.claude/hooks/` which is the runtime location).

## Test plan

- [ ] Verify `grep -rn '\.claude/state/' daemon/src/ scripts/ --include="*.ts" --include="*.sh" | grep -v __tests__ | grep -v context-watchdog` returns no matches
- [ ] Confirm Telegram adapter reads/writes state files from `.kithkit/state/` at runtime
- [ ] Confirm channel routing reads channel from `.kithkit/state/channel.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)