### PR TITLE
fix(orchestrator): preserve full task body in escalate INSERT

### DIFF
--- a/daemon/src/__tests__/orchestrator-escalate.test.ts
+++ b/daemon/src/__tests__/orchestrator-escalate.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression tests for POST /api/orchestrator/escalate — task field preservation.
+ *
+ * Root cause: the original INSERT used `task.slice(0, 200)` for title and
+ * `context ?? task` for description, silently dropping the full task body
+ * whenever a context was provided. BMO's digest task 24dab43c lost its
+ * delivery instructions this way.
+ *
+ * These tests exercise:
+ *   1. buildTaskFields() pure helper (unit)
+ *   2. Full description preservation when both task + context are provided (unit)
+ *   3. Title derived from first line, capped at 200 chars (unit)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTaskFields } from '../api/orchestrator.js';
+
+// ── Unit tests for buildTaskFields ──────────────────────────────────────────
+
+describe('buildTaskFields', { concurrency: 1 }, () => {
+
+  describe('title derivation', () => {
+    it('uses the first non-empty line as title', () => {
+      const task = 'Send the weekly digest\n\nWith lots of body content here.';
+      const { titleText } = buildTaskFields(task);
+      assert.equal(titleText, 'Send the weekly digest');
+    });
+
+    it('skips blank leading lines to find first non-empty line', () => {
+      const task = '\n\n  \nActual first line\nSecond line';
+      const { titleText } = buildTaskFields(task);
+      assert.equal(titleText, 'Actual first line');
+    });
+
+    it('caps title at 200 chars', () => {
+      const longLine = 'A'.repeat(300);
+      const task = `${longLine}\nmore content`;
+      const { titleText } = buildTaskFields(task);
+      assert.equal(titleText.length, 200);
+      assert.equal(titleText, longLine.slice(0, 200));
+    });
+
+    it('falls back to task.slice(0,200) when all lines are blank', () => {
+      const task = '   \n   \n   ';
+      const { titleText } = buildTaskFields(task);
+      assert.equal(titleText, task.slice(0, 200));
+    });
+
+    it('trims whitespace from title', () => {
+      const task = '   Trimmed title   \nBody content';
+      const { titleText } = buildTaskFields(task);
+      assert.equal(titleText, 'Trimmed title');
+    });
+  });
+
+  describe('description preservation — no context', () => {
+    it('description is the full task body when no context provided', () => {
+      const SENTINEL = 'SENTINEL_TASK_FULL_BODY_DO_NOT_LOSE';
+      const task = `First line\n\nParagraph two. ${SENTINEL}\n\nMore paragraphs follow.`;
+      const { descriptionText } = buildTaskFields(task);
+      assert.equal(descriptionText, task, 'description must equal full task');
+      assert.ok(descriptionText.includes(SENTINEL), 'sentinel must survive');
+    });
+
+    it('description preserves task body longer than 200 chars', () => {
+      const task = 'A'.repeat(500);
+      const { descriptionText } = buildTaskFields(task);
+      assert.equal(descriptionText.length, 500);
+    });
+  });
+
+  describe('description preservation — with context (regression for 24dab43c)', () => {
+    it('description contains BOTH task sentinel AND context sentinel', () => {
+      const SENTINEL_TASK = 'SENTINEL_TASK_FULL_BODY_DO_NOT_LOSE';
+      const SENTINEL_CTX = 'SENTINEL_CONTEXT_DO_NOT_LOSE';
+
+      const task =
+        'Send the weekly digest to all subscribers\n\n' +
+        'Delivery instructions: use Telegram channel -5046483444. ' +
+        SENTINEL_TASK.repeat(5) + '\n\n' +
+        'Additional body paragraph that is definitely longer than two hundred characters so we can confirm the full task body survives the insert without truncation. End of task body.';
+
+      const context =
+        'Background context from previous session. ' +
+        SENTINEL_CTX.repeat(5) + '\n\n' +
+        'More context lines follow here to ensure the context section is also well beyond 300 characters in length for a thorough sentinel check.';
+
+      assert.ok(task.length > 300, `task should be >300 chars, got ${task.length}`);
+      assert.ok(context.length > 300, `context should be >300 chars, got ${context.length}`);
+
+      const { titleText, descriptionText } = buildTaskFields(task, context);
+
+      // title is from first line, ≤200 chars
+      assert.equal(titleText, 'Send the weekly digest to all subscribers');
+      assert.ok(titleText.length <= 200, `title length ${titleText.length} should be ≤200`);
+
+      // description contains full task body
+      assert.ok(
+        descriptionText.includes(SENTINEL_TASK),
+        'description must contain task sentinel — full task body must be preserved',
+      );
+
+      // description contains context
+      assert.ok(
+        descriptionText.includes(SENTINEL_CTX),
+        'description must contain context sentinel — context must be preserved',
+      );
+
+      // description starts with the task (not context)
+      assert.ok(
+        descriptionText.startsWith('Send the weekly digest'),
+        'description should start with task body',
+      );
+
+      // context is in a delimited section
+      assert.ok(
+        descriptionText.includes('## Context\n'),
+        'context should be in a ## Context section',
+      );
+      assert.ok(
+        descriptionText.includes('---'),
+        'description should have a horizontal rule separator',
+      );
+    });
+
+    it('context follows task body, separated by delimiter', () => {
+      const task = 'Do the thing\n\nWith full body.';
+      const context = 'Extra background here.';
+      const { descriptionText } = buildTaskFields(task, context);
+
+      const expected = `${task}\n\n---\n\n## Context\n${context}`;
+      assert.equal(descriptionText, expected);
+    });
+
+    it('omits context section when context is undefined', () => {
+      const task = 'Do the thing\n\nWith full body.';
+      const { descriptionText } = buildTaskFields(task, undefined);
+      assert.equal(descriptionText, task);
+      assert.ok(!descriptionText.includes('## Context'));
+    });
+  });
+
+  describe('title <= 200 chars in all cases', () => {
+    it('title is always ≤200 chars regardless of input', () => {
+      for (const task of [
+        'Short',
+        'A'.repeat(201),
+        '\n\n' + 'B'.repeat(300) + '\nMore',
+        'Has spaces   \nNext line',
+      ]) {
+        const { titleText } = buildTaskFields(task);
+        assert.ok(titleText.length <= 200, `title exceeds 200 chars for input: ${task.slice(0, 30)}`);
+      }
+    });
+  });
+});

--- a/daemon/src/api/orchestrator.ts
+++ b/daemon/src/api/orchestrator.ts
@@ -39,6 +39,24 @@ let pendingShutdownTimer: ReturnType<typeof setTimeout> | null = null;
 
 const escalateLimiter = createRateLimiter('escalate', 20);
 
+/**
+ * Build task title and description from escalate fields, preserving all content.
+ *
+ * - titleText: first non-empty line of task, trimmed and capped at 200 chars
+ * - descriptionText: full task body, with context appended as a delimited section if provided
+ */
+export function buildTaskFields(
+  task: string,
+  context?: string,
+): { titleText: string; descriptionText: string } {
+  const firstLine = task.split('\n').find(l => l.trim().length > 0) ?? '';
+  const titleText = firstLine.trim().slice(0, 200) || task.slice(0, 200);
+  const descriptionText = context
+    ? `${task}\n\n---\n\n## Context\n${context}`
+    : task;
+  return { titleText, descriptionText };
+}
+
 // ── Route handler ────────────────────────────────────────────
 
 export async function handleOrchestratorRoute(
@@ -73,18 +91,19 @@ export async function handleOrchestratorRoute(
     const ts = new Date().toISOString();
     const priority = typeof body.priority === 'number' ? body.priority : 0;
     const workNotes = typeof body.work_notes === 'string' ? body.work_notes : null;
+    const { titleText, descriptionText } = buildTaskFields(task, context);
     exec(
       `INSERT INTO orchestrator_tasks (id, title, description, status, priority, work_notes, created_at, updated_at)
        VALUES (?, ?, ?, 'pending', ?, ?, ?, ?)`,
       taskId,
-      task.slice(0, 200),
-      context ?? task,
+      titleText,
+      descriptionText,
       priority,
       workNotes,
       ts,
       ts,
     );
-    log.info('Created orchestrator task', { taskId, title: task.slice(0, 100) });
+    log.info('Created orchestrator task', { taskId, title: titleText });
 
     if (!alive) {
       // Cancel any pending shutdown timer — a new spawn supersedes a pending shutdown


### PR DESCRIPTION
## Root cause

`POST /api/orchestrator/escalate` stored tasks into `orchestrator_tasks` using:

```ts
task.slice(0, 200)   // → title (truncated)
context ?? task      // → description (drops task body when context present)
```

When callers passed **both** `task` and `context`, the full task body was silently dropped. Only the first 200 chars survived in the title; `description` held only the context. Any orchestrator reading from the task queue (`GET /api/orchestrator/tasks`) never saw the rest of the task.

This caused **BMO's digest task `24dab43c`** to lose its delivery instructions — the entire task body (>200 chars) was truncated to the title, and the `description` field held only the context string passed separately.

## Fix

Introduce `buildTaskFields(task, context)` (exported for unit testing):

- **`titleText`**: first non-empty line of `task`, trimmed, capped at 200 chars. Falls back to `task.slice(0, 200)` if all lines are blank.
- **`descriptionText`**: always the **full** `task` body. When `context` is provided, it is appended as a delimited `## Context` section so both the task body and the context survive into the DB row.

The `sendMessage()` calls that carry `task`+`context` in their JSON body are unchanged — they already preserved all data.

## Regression test

`daemon/src/__tests__/orchestrator-escalate.test.ts` — 11 unit tests for `buildTaskFields` including sentinel-string checks that confirm BOTH the full task body (>300 chars) and the full context (>300 chars) appear in `descriptionText`.

Test run: **11 pass / 0 fail**

```
# tests 11
# pass 11
# fail 0
```

## TSC status

Pre-existing upstream errors remain unchanged (missing imports in `buildOrchestratorPrompt` and `sdk-bridge.ts` unrelated to this PR). No new errors introduced.

## Reviewer

Requesting @RRLLC-BMO for review.